### PR TITLE
KAN-4: Fix signup error - add rollback and isolate post-creation steps

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,6 +3,7 @@
 ## Jira Workflow
 
 When the user says **"let's work on 1234"**:
+
 1. Look up Jira issue **KAN-1234**
 2. If it exists, create a new branch named `kan-1234` from `main`
 3. Move the Jira issue to **In Progress**
@@ -10,6 +11,7 @@ When the user says **"let's work on 1234"**:
 5. Propose a plan — **do not execute until the user approves**
 
 When the user says **"let's work on the next jira"**:
+
 1. Search for Jira issues in the **TO DO** column (status), ordered by rank
 2. Pick the top issue
 3. Follow the same process: create branch from `main`, move to In Progress, read the issue, propose a plan, wait for approval
@@ -17,7 +19,8 @@ When the user says **"let's work on the next jira"**:
 ## Push Workflow
 
 When the user says **"push"**:
+
 1. Push the current branch to remote
 2. Add a comment to the Jira issue summarizing the changes
-3. Move the Jira issue to **In Review**
+3. Move the Jira issue to **Code Review**
 4. Open a pull request against `main`

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/react-dom": "^19.1.6",
     "@types/react-pdf": "^7.0.0",
     "@vitejs/plugin-react": "^4.6.0",
+    "concurrently": "^9.2.1",
     "esbuild": "^0.21.5",
     "eslint": "^9.34.0",
     "eslint-plugin-import": "^2.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.6.0
         version: 4.7.0(vite@5.4.21(@types/node@24.10.4))
+      concurrently:
+        specifier: ^9.2.1
+        version: 9.2.1
       esbuild:
         specifier: ^0.21.5
         version: 0.21.5
@@ -1776,6 +1779,11 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  concurrently@9.2.1:
+    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
@@ -4079,6 +4087,10 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
+
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
@@ -4249,6 +4261,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
   supports-hyperlinks@3.2.0:
     resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
     engines: {node: '>=14.18'}
@@ -4322,6 +4338,10 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   triple-beam@1.4.1:
     resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
@@ -6557,6 +6577,15 @@ snapshots:
       - supports-color
 
   concat-map@0.0.1: {}
+
+  concurrently@9.2.1:
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
 
   config-chain@1.1.13:
     dependencies:
@@ -9546,6 +9575,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shell-quote@1.8.3: {}
+
   side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -9768,6 +9799,10 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
   supports-hyperlinks@3.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -9872,6 +9907,8 @@ snapshots:
       lodash: 4.17.23
 
   tr46@0.0.3: {}
+
+  tree-kill@1.2.2: {}
 
   triple-beam@1.4.1: {}
 

--- a/src/components/Signup/hooks/useData.ts
+++ b/src/components/Signup/hooks/useData.ts
@@ -37,6 +37,7 @@ export function useSignupData(): SignupData & {
         'pending_invitations',
         buildConstraints({
           eq: { invitation_code: inviteCode, status: 'pending' },
+          limit: 1,
         })
       ).then(({ data, error }) => {
         setLoadingInvitation(false);

--- a/src/components/Signup/hooks/useHandlers.ts
+++ b/src/components/Signup/hooks/useHandlers.ts
@@ -1,5 +1,6 @@
 import {
   createUserWithEmailAndPassword,
+  deleteUser,
   sendEmailVerification,
   updateProfile,
 } from 'firebase/auth';
@@ -47,45 +48,59 @@ export function useSignupHandlers(
       const userCredential = await createUserWithEmailAndPassword(auth, email, password);
       const user = userCredential.user;
 
-      // Update profile with display name
-      await updateProfile(user, {
-        displayName: `${firstName} ${lastName}`,
-      });
-
-      // Check if this is an invitation signup
       const isInvitationSignup = invitationData !== null && invitationData !== undefined;
 
-      // Create user profile in Firestore
-      await createDocument(
-        'users',
-        {
-          id: user.uid,
-          email: user.email,
-          user_type: role,
-          teacher_id: role === 'student' && teacherId ? teacherId : null,
-          first_name: firstName,
-          last_name: lastName,
-          created_at: new Date().toISOString(),
-          verified_via_invitation: isInvitationSignup ? true : false,
-        },
-        user.uid
-      );
-
-      // Only send email verification if this is NOT an invitation signup
-      // (invitation signups already confirmed email by clicking the link)
-      if (!isInvitationSignup) {
-        await sendEmailVerification(user);
+      // Update profile — non-critical, don't rollback on failure
+      try {
+        await updateProfile(user, {
+          displayName: `${firstName} ${lastName}`,
+        });
+      } catch (profileError) {
+        console.error('Failed to update profile display name:', profileError);
       }
 
-      // Delete the pending invitation after successful signup
+      // Create user profile in Firestore — critical step, rollback Auth user on failure
+      try {
+        await createDocument(
+          'users',
+          {
+            id: user.uid,
+            email: user.email,
+            user_type: role,
+            teacher_id: role === 'student' && teacherId ? teacherId : null,
+            first_name: firstName,
+            last_name: lastName,
+            created_at: new Date().toISOString(),
+            verified_via_invitation: isInvitationSignup ? true : false,
+          },
+          user.uid
+        );
+      } catch (firestoreError) {
+        // Firestore doc failed — delete the Auth user so they can retry
+        console.error('Failed to create Firestore user doc, rolling back Auth user:', firestoreError);
+        try {
+          await deleteUser(user);
+        } catch (deleteError) {
+          console.error('Failed to rollback Auth user:', deleteError);
+        }
+        throw new Error('Account creation failed. Please try again.');
+      }
+
+      // Send email verification for non-invitation signups — non-critical
+      if (!isInvitationSignup) {
+        try {
+          await sendEmailVerification(user);
+        } catch (verifyError) {
+          console.error('Failed to send verification email:', verifyError);
+        }
+      }
+
+      // Delete the pending invitation after successful signup — non-critical
       if (isInvitationSignup) {
         try {
-          // If we have invitation data, delete it directly
           if (invitationData && invitationData.id) {
             await deleteDocument('pending_invitations', invitationData.id);
-            console.log('Deleted pending invitation:', invitationData.id);
           } else {
-            // Fallback: search for pending invitation by email
             const { data: pendingInvites } = await getDocuments(
               'pending_invitations',
               buildConstraints({
@@ -95,47 +110,42 @@ export function useSignupHandlers(
 
             if (pendingInvites && pendingInvites.length > 0) {
               await deleteDocument('pending_invitations', pendingInvites[0].id);
-              console.log('Deleted pending invitation for', user.email);
             }
           }
         } catch (error) {
-          // Don't fail signup if we can't delete the pending invitation
           console.error('Error deleting pending invitation:', error);
         }
       }
 
       setLoading(false);
 
-      // Different messaging based on whether email verification was sent
+      // Redirect based on signup type
       if (isInvitationSignup) {
-        // For invitation signups, user is already verified - redirect to dashboard
         if (role === 'student') {
-          // Check if student has any projects
-          const { data: projectData, error: projectError } = await getDocuments(
-            'projects',
-            buildConstraints({
-              eq: { student_id: user.uid },
-              limit: 1,
-            })
-          );
+          try {
+            const { data: projectData } = await getDocuments(
+              'projects',
+              buildConstraints({
+                eq: { student_id: user.uid },
+                limit: 1,
+              })
+            );
 
-          if (projectError) {
-            showAlert('Account created! Redirecting to dashboard...', 'Success');
-            navigate('/student/dashboard');
-          } else if (!projectData || (projectData as any[]).length === 0) {
-            // No projects found, redirect to create project screen
-            navigate('/createProject');
-          } else {
+            if (!projectData || (projectData as any[]).length === 0) {
+              navigate('/createProject');
+            } else {
+              navigate('/student/dashboard');
+            }
+          } catch {
+            // Project check failed — account is created, just go to dashboard
             navigate('/student/dashboard');
           }
         } else if (role === 'teacher') {
           navigate('/teacher/dashboard');
         } else {
-          // Fallback
           navigate('/login');
         }
       } else {
-        // For non-invitation signups, require email verification
         if (setShowEmailModal) {
           setShowEmailModal(true);
         } else {

--- a/src/teacher/components/Dashboard/StudentsList.tsx
+++ b/src/teacher/components/Dashboard/StudentsList.tsx
@@ -277,14 +277,18 @@ export default function StudentsList({
                   </TableCell>
                   <TableCell>
                     <Chip
-                      label={student.status === 'pending' ? 'Invitation Sent' : 'Active'}
+                      label={
+                        student.status === 'pending'
+                          ? `Invitation Sent${student.invited_at ? ` ${formatDate(student.invited_at)}` : ''}`
+                          : 'Active'
+                      }
                       color={student.status === 'pending' ? 'warning' : 'success'}
                       size="small"
                     />
                   </TableCell>
                   <TableCell>
                     {student.status === 'pending'
-                      ? formatDate(student.invited_at || '')
+                      ? '—'
                       : formatDate(student.created_at)}
                   </TableCell>
                   <TableCell align="center">


### PR DESCRIPTION
## KAN-4: Signup Error

Fixes a bug where students received an error during signup but their account was actually created, making retry impossible.

### Changes
- **Added rollback**: If Firestore user doc creation fails after Auth account creation, the Auth user is deleted so the student can retry cleanly
- **Isolated non-critical steps**: `updateProfile`, `sendEmailVerification`, and invitation cleanup each have their own try/catch — one failure no longer blocks the entire signup
- **Fixed misleading error flow**: Project lookup failure now silently redirects to dashboard instead of showing a confusing success alert

### Updated copilot-instructions
- Changed push workflow to use new **Code Review** Jira status