### PR TITLE
feat(KAN-16): Add submission history for multiple PDF uploads per step

### DIFF
--- a/src/components/SubmissionHistory/SubmissionHistory.tsx
+++ b/src/components/SubmissionHistory/SubmissionHistory.tsx
@@ -1,0 +1,175 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Box,
+  Typography,
+  Chip,
+  IconButton,
+  Button,
+  Collapse,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  CircularProgress,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import DownloadIcon from '@mui/icons-material/Download';
+import { getDocuments, buildConstraints } from '../../utils/firebaseHelpers';
+import type { Submission } from '../../types';
+
+interface SubmissionHistoryProps {
+  projectId: string;
+  stepNumber: number;
+}
+
+export default function SubmissionHistory({ projectId, stepNumber }: SubmissionHistoryProps) {
+  const [submissions, setSubmissions] = useState<Submission[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    if (!projectId) {
+      setLoading(false);
+      return;
+    }
+
+    const fetchSubmissions = async () => {
+      try {
+        const { data } = await getDocuments(
+          'submissions',
+          buildConstraints({
+            eq: { project_id: projectId, step_number: stepNumber },
+          })
+        );
+        const sorted = ((data as Submission[]) || []).sort(
+          (a, b) => new Date(b.submitted_at).getTime() - new Date(a.submitted_at).getTime()
+        );
+        setSubmissions(sorted);
+      } catch (err) {
+        console.error('Error fetching submission history:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchSubmissions();
+  }, [projectId, stepNumber]);
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+        <CircularProgress size={20} />
+      </Box>
+    );
+  }
+
+  if (submissions.length === 0) return null;
+
+  const formatDate = (dateStr: string) => {
+    const d = new Date(dateStr);
+    return d.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  };
+
+  return (
+    <Box>
+      <Box
+        onClick={() => setExpanded(!expanded)}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          cursor: 'pointer',
+          gap: 1,
+          py: 0.5,
+          '&:hover': { opacity: 0.8 },
+        }}
+      >
+        <ExpandMoreIcon
+          fontSize="small"
+          sx={{
+            transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+            transition: 'transform 0.2s',
+          }}
+        />
+        <Typography variant="body2" sx={{ fontWeight: 600 }}>
+          Submission History
+        </Typography>
+        <Chip
+          label={submissions.length}
+          size="small"
+          sx={{ height: 20, fontSize: '0.7rem' }}
+        />
+      </Box>
+
+      <Collapse in={expanded}>
+        <List dense disablePadding sx={{ pl: 1 }}>
+          {submissions.map((sub, index) => (
+            <ListItem
+              key={sub.submission_id || index}
+              sx={{
+                py: 0.5,
+                borderLeft: '2px solid',
+                borderColor: index === 0 ? 'primary.main' : 'divider',
+                ml: 1,
+                pl: 1.5,
+              }}
+            >
+              <ListItemIcon sx={{ minWidth: 32 }}>
+                <PictureAsPdfIcon fontSize="small" color={index === 0 ? 'primary' : 'disabled'} />
+              </ListItemIcon>
+              <ListItemText
+                primary={
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Typography variant="body2" sx={{ fontSize: '0.8rem' }}>
+                      {formatDate(sub.submitted_at)}
+                    </Typography>
+                    {index === 0 && (
+                      <Chip
+                        label="Current"
+                        size="small"
+                        color="primary"
+                        sx={{ height: 18, fontSize: '0.65rem' }}
+                      />
+                    )}
+                  </Box>
+                }
+              />
+              {sub.file_url && (
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                  {index > 0 && (
+                    <Button
+                      size="small"
+                      component="a"
+                      href={sub.file_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={{ fontSize: '0.7rem', py: 0, px: 0.5, minWidth: 0, textTransform: 'none' }}
+                    >
+                      View
+                    </Button>
+                  )}
+                  <IconButton
+                    component="a"
+                    size="small"
+                    href={sub.file_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    sx={{ p: 0.25 }}
+                  >
+                    <DownloadIcon fontSize="small" />
+                  </IconButton>
+                </Box>
+              )}
+            </ListItem>
+          ))}
+        </List>
+      </Collapse>
+    </Box>
+  );
+}

--- a/src/student/components/Step1Upload/Step1Upload.tsx
+++ b/src/student/components/Step1Upload/Step1Upload.tsx
@@ -14,6 +14,7 @@ import { useStep1UploadData } from './hooks/useData';
 import { useStep1UploadHandlers } from './hooks/useHandlers';
 import SharedHeader from '../SharedHeader/SharedHeader';
 import CommentThread from '../../../components/CommentThread/CommentThread';
+import SubmissionHistory from '../../../components/SubmissionHistory/SubmissionHistory';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 
@@ -248,6 +249,12 @@ export default function Step1Upload() {
                 Uploading your file...
               </Typography>
             </Box>
+          )}
+
+          {projectId && (
+            <Paper sx={{ p: 2 }}>
+              <SubmissionHistory projectId={projectId} stepNumber={1} />
+            </Paper>
           )}
 
           {projectId && (

--- a/src/student/components/Step2Upload/Step2Upload.tsx
+++ b/src/student/components/Step2Upload/Step2Upload.tsx
@@ -14,6 +14,7 @@ import { useStep2UploadData } from './hooks/useData';
 import { useStep2UploadHandlers } from './hooks/useHandlers';
 import SharedHeader from '../SharedHeader/SharedHeader';
 import CommentThread from '../../../components/CommentThread/CommentThread';
+import SubmissionHistory from '../../../components/SubmissionHistory/SubmissionHistory';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 
@@ -219,6 +220,12 @@ export default function Step2Upload() {
                 Uploading your file...
               </Typography>
             </Box>
+          )}
+
+          {projectId && (
+            <Paper sx={{ p: 2 }}>
+              <SubmissionHistory projectId={projectId} stepNumber={2} />
+            </Paper>
           )}
 
           {projectId && (

--- a/src/student/components/Step3Upload/Step3Upload.tsx
+++ b/src/student/components/Step3Upload/Step3Upload.tsx
@@ -14,6 +14,7 @@ import { useStep3UploadData } from './hooks/useData';
 import { useStep3UploadHandlers } from './hooks/useHandlers';
 import SharedHeader from '../SharedHeader/SharedHeader';
 import CommentThread from '../../../components/CommentThread/CommentThread';
+import SubmissionHistory from '../../../components/SubmissionHistory/SubmissionHistory';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 
@@ -219,6 +220,12 @@ export default function Step3Upload() {
                 Uploading your file...
               </Typography>
             </Box>
+          )}
+
+          {projectId && (
+            <Paper sx={{ p: 2 }}>
+              <SubmissionHistory projectId={projectId} stepNumber={3} />
+            </Paper>
           )}
 
           {projectId && (

--- a/src/student/components/Step4Upload/Step4Upload.tsx
+++ b/src/student/components/Step4Upload/Step4Upload.tsx
@@ -14,6 +14,7 @@ import { useStep4UploadData } from './hooks/useData';
 import { useStep4UploadHandlers } from './hooks/useHandlers';
 import SharedHeader from '../SharedHeader/SharedHeader';
 import CommentThread from '../../../components/CommentThread/CommentThread';
+import SubmissionHistory from '../../../components/SubmissionHistory/SubmissionHistory';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 
@@ -219,6 +220,12 @@ export default function Step4Upload() {
                 Uploading your file...
               </Typography>
             </Box>
+          )}
+
+          {projectId && (
+            <Paper sx={{ p: 2 }}>
+              <SubmissionHistory projectId={projectId} stepNumber={4} />
+            </Paper>
           )}
 
           {projectId && (

--- a/src/student/components/Step5Upload/Step5Upload.tsx
+++ b/src/student/components/Step5Upload/Step5Upload.tsx
@@ -16,6 +16,7 @@ import { useStep5UploadData } from './hooks/useData';
 import { useStep5UploadHandlers } from './hooks/useHandlers';
 import SharedHeader from '../SharedHeader/SharedHeader';
 import CommentThread from '../../../components/CommentThread/CommentThread';
+import SubmissionHistory from '../../../components/SubmissionHistory/SubmissionHistory';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 
@@ -246,6 +247,12 @@ export default function Step5Upload() {
                 Uploading your file...
               </Typography>
             </Box>
+          )}
+
+          {projectId && (
+            <Paper sx={{ p: 2 }}>
+              <SubmissionHistory projectId={projectId} stepNumber={5} />
+            </Paper>
           )}
 
           {projectId && (

--- a/src/teacher/components/Dashboard/StudentsList.tsx
+++ b/src/teacher/components/Dashboard/StudentsList.tsx
@@ -30,6 +30,7 @@ import {
 } from '@mui/icons-material';
 import { Project } from '../../../types';
 import CommentThread from '../../../components/CommentThread/CommentThread';
+import SubmissionHistory from '../../../components/SubmissionHistory/SubmissionHistory';
 import { getDocuments, buildConstraints } from '../../../utils/firebaseHelpers';
 
 interface Student {
@@ -788,6 +789,30 @@ export default function StudentsList({
                                               </Table>
                                             </Box>
                                           )}
+
+                                          {/* Submission history per step */}
+                                          {activeSteps.length > 0 && (
+                                            <Box
+                                              sx={{
+                                                mx: 2,
+                                                my: 1,
+                                                p: 1.5,
+                                                bgcolor: '#071e3d',
+                                                borderRadius: 1,
+                                                border: '1px solid',
+                                                borderColor: 'divider',
+                                              }}
+                                            >
+                                              {activeSteps.map((step) => (
+                                                <SubmissionHistory
+                                                  key={step.stepNumber}
+                                                  projectId={project.project_id}
+                                                  stepNumber={step.stepNumber}
+                                                />
+                                              ))}
+                                            </Box>
+                                          )}
+
                                           {/* Project comment thread */}
                                           <Box
                                             sx={{

--- a/src/teacher/components/StepApproval/StepApproval.tsx
+++ b/src/teacher/components/StepApproval/StepApproval.tsx
@@ -30,6 +30,7 @@ import { useStepApprovalHandlers } from './hooks/useHandlers';
 import AlertDialog from '../../../components/AlertDialog/AlertDialog';
 import CommentThread from '../../../components/CommentThread/CommentThread';
 import type { CommentThreadHandle } from '../../../components/CommentThread/CommentThread';
+import SubmissionHistory from '../../../components/SubmissionHistory/SubmissionHistory';
 
 // Use CDN that matches installed pdfjs-dist version
 pdfjs.GlobalWorkerOptions.workerSrc = `https://unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;
@@ -409,6 +410,10 @@ export default function StepApproval() {
             {/* Bottom panel - always visible */}
             <Paper sx={{ flexShrink: 0, p: 2 }}>
               <Stack spacing={2}>
+                <SubmissionHistory
+                  projectId={projectId!}
+                  stepNumber={parseInt(stepNumber!)}
+                />
                 <CommentThread
                   ref={commentThreadRef}
                   projectId={projectId!}


### PR DESCRIPTION
- Create SubmissionHistory component showing all submissions per step
- Current submission marked with 'Current' chip, older ones have View/Download
- View opens old PDFs in new browser tab for comparison
- Add to all 5 student step upload pages
- Add to teacher StepApproval page
- Add to teacher dashboard expanded project panel per active step