### PR TITLE
feat(KAN-5): Add helper text to project title field

### DIFF
--- a/src/components/CreateProject/CreateProject.tsx
+++ b/src/components/CreateProject/CreateProject.tsx
@@ -85,6 +85,7 @@ export default function CreateProject() {
               required
               fullWidth
               variant="outlined"
+              helperText="Unsure of your project? Provide a temporary name, e.g. History Project, Art Project. You can change this later."
             />
 
             <FormControl component="fieldset" required>


### PR DESCRIPTION
- Guide students who don't have a project name yet
- 'Provide a temporary name, e.g. History Project, Art Project. You can change this later.'