### PR TITLE
feat(KAN-14): Improve contrast on comment box and revision button

### DIFF
--- a/src/components/CommentThread/CommentThread.tsx
+++ b/src/components/CommentThread/CommentThread.tsx
@@ -344,7 +344,9 @@ const CommentThread = forwardRef<CommentThreadHandle, CommentThreadProps>(functi
           display: 'flex',
           alignItems: 'center',
           gap: 1,
-          bgcolor: 'rgba(0,0,0,0.15)',
+          bgcolor: 'rgba(255,255,255,0.08)',
+          border: '1px solid',
+          borderColor: 'rgba(255,255,255,0.2)',
           borderRadius: '0 0 8px 8px',
           px: 1.5,
           py: 0.5,
@@ -360,9 +362,12 @@ const CommentThread = forwardRef<CommentThreadHandle, CommentThreadProps>(functi
           multiline
           maxRows={3}
           disabled={sending}
-          variant="standard"
-          InputProps={{ disableUnderline: true }}
-          sx={{ '& .MuiInputBase-input': { py: 0.75 } }}
+          variant="outlined"
+          sx={{
+            '& .MuiInputBase-input': { py: 0.75 },
+            '& .MuiOutlinedInput-root': { bgcolor: 'rgba(255,255,255,0.12)' },
+            '& .MuiOutlinedInput-notchedOutline': { borderColor: 'rgba(255,255,255,0.25)' },
+          }}
         />
         <IconButton
           onClick={handleSend}

--- a/src/teacher/components/StepApproval/StepApproval.tsx
+++ b/src/teacher/components/StepApproval/StepApproval.tsx
@@ -423,7 +423,8 @@ export default function StepApproval() {
 
                 <Stack direction="row" spacing={2} justifyContent="flex-end">
                   <Button
-                    variant="outlined"
+                    variant="contained"
+                    color="warning"
                     onClick={async () => {
                       popupRef.current?.close();
                       // Submit any text in the comment field first


### PR DESCRIPTION
- Comment compose area: lighter background with visible border
- Comment text field: outlined variant with light background fill
- Return to Student button: contained warning (amber) instead of outlined