### PR TITLE
fix(KAN-5): Improve project title helper text and add placeholder

### DIFF
--- a/src/components/CreateProject/CreateProject.tsx
+++ b/src/components/CreateProject/CreateProject.tsx
@@ -80,12 +80,16 @@ export default function CreateProject() {
             <TextField
               type="text"
               label="Project Title"
+              placeholder="e.g. History Project, Art Project"
               value={projectTitle}
               onChange={(e) => setProjectTitle(e.target.value)}
               required
               fullWidth
               variant="outlined"
-              helperText="Unsure of your project? Provide a temporary name, e.g. History Project, Art Project. You can change this later."
+              helperText="Unsure of your project? Provide a temporary name. You can change this later."
+              FormHelperTextProps={{
+                sx: { fontStyle: 'italic', fontSize: '0.85rem', color: 'text.secondary' },
+              }}
             />
 
             <FormControl component="fieldset" required>


### PR DESCRIPTION
## KAN-5: Student Sign-In Process: Project Title

Improves the project title field during first-time student sign-in to better guide students who may not have a project name yet.

### Changes
- Added placeholder text (`e.g. History Project, Art Project`) inside the input field for immediate examples
- Shortened helper text to avoid redundancy: *"Unsure of your project? Provide a temporary name. You can change this later."*
- Styled helper text (italic, slightly larger font) for better visibility

### Jira
[KAN-5](https://orbilius.atlassian.net/browse/KAN-5)