### PR TITLE
fix(KAN-12): Fix washed-out Return to Dashboard button on submission …

### DIFF
--- a/src/student/components/Step1Upload/Step1Upload.tsx
+++ b/src/student/components/Step1Upload/Step1Upload.tsx
@@ -162,9 +162,9 @@ export default function Step1Upload() {
                 You may close this window or return to your dashboard.
               </Typography>
               <Button
-                variant="contained"
+                variant="outlined"
                 onClick={() => navigate('/student/dashboard')}
-                sx={{ mt: 2, bgcolor: 'white', color: 'success.dark', '&:hover': { bgcolor: 'grey.200' } }}
+                sx={{ mt: 2, color: 'white', borderColor: 'white', '&:hover': { bgcolor: 'rgba(255,255,255,0.1)', borderColor: 'white' } }}
               >
                 Return to Dashboard
               </Button>

--- a/src/student/components/Step2Upload/Step2Upload.tsx
+++ b/src/student/components/Step2Upload/Step2Upload.tsx
@@ -150,9 +150,9 @@ export default function Step2Upload() {
                 You may close this window or return to your dashboard.
               </Typography>
               <Button
-                variant="contained"
+                variant="outlined"
                 onClick={() => navigate('/student/dashboard')}
-                sx={{ mt: 2, bgcolor: 'white', color: 'success.dark', '&:hover': { bgcolor: 'grey.200' } }}
+                sx={{ mt: 2, color: 'white', borderColor: 'white', '&:hover': { bgcolor: 'rgba(255,255,255,0.1)', borderColor: 'white' } }}
               >
                 Return to Dashboard
               </Button>

--- a/src/student/components/Step3Upload/Step3Upload.tsx
+++ b/src/student/components/Step3Upload/Step3Upload.tsx
@@ -150,9 +150,9 @@ export default function Step3Upload() {
                 You may close this window or return to your dashboard.
               </Typography>
               <Button
-                variant="contained"
+                variant="outlined"
                 onClick={() => navigate('/student/dashboard')}
-                sx={{ mt: 2, bgcolor: 'white', color: 'success.dark', '&:hover': { bgcolor: 'grey.200' } }}
+                sx={{ mt: 2, color: 'white', borderColor: 'white', '&:hover': { bgcolor: 'rgba(255,255,255,0.1)', borderColor: 'white' } }}
               >
                 Return to Dashboard
               </Button>

--- a/src/student/components/Step4Upload/Step4Upload.tsx
+++ b/src/student/components/Step4Upload/Step4Upload.tsx
@@ -150,9 +150,9 @@ export default function Step4Upload() {
                 You may close this window or return to your dashboard.
               </Typography>
               <Button
-                variant="contained"
+                variant="outlined"
                 onClick={() => navigate('/student/dashboard')}
-                sx={{ mt: 2, bgcolor: 'white', color: 'success.dark', '&:hover': { bgcolor: 'grey.200' } }}
+                sx={{ mt: 2, color: 'white', borderColor: 'white', '&:hover': { bgcolor: 'rgba(255,255,255,0.1)', borderColor: 'white' } }}
               >
                 Return to Dashboard
               </Button>

--- a/src/student/components/Step5Upload/Step5Upload.tsx
+++ b/src/student/components/Step5Upload/Step5Upload.tsx
@@ -166,9 +166,9 @@ export default function Step5Upload() {
                 </Typography>
               )}
               <Button
-                variant="contained"
+                variant="outlined"
                 onClick={() => navigate('/student/dashboard')}
-                sx={{ mt: 2, bgcolor: 'white', color: 'success.dark', '&:hover': { bgcolor: 'grey.200' } }}
+                sx={{ mt: 2, color: 'white', borderColor: 'white', '&:hover': { bgcolor: 'rgba(255,255,255,0.1)', borderColor: 'white' } }}
               >
                 Return to Dashboard
               </Button>


### PR DESCRIPTION
…screen

Switch from variant=contained with white bgcolor to variant=outlined with white border/text on all 5 step upload components. Fixes blue color bleed- through from MUI primary palette on the dark green success background.