### PR TITLE
refactor: code cleanup — remove console.logs, move drag state/handlers to hooks

### DIFF
--- a/src/admin/api/adminApi.ts
+++ b/src/admin/api/adminApi.ts
@@ -147,11 +147,7 @@ export async function fetchTeachers() {
 }
 
 export async function deleteTeacher(teacherId: string) {
-  // Call Firebase Cloud Function to delete teacher and students
   try {
-    console.log('Calling deleteTeacher Cloud Function for:', teacherId);
-    console.log('Function URL:', CLOUD_FUNCTIONS.deleteTeacher);
-
     const response = await fetch(CLOUD_FUNCTIONS.deleteTeacher, {
       method: 'POST',
       headers: {
@@ -160,10 +156,7 @@ export async function deleteTeacher(teacherId: string) {
       body: JSON.stringify({ teacherId }),
     });
 
-    console.log('Delete teacher response status:', response.status);
-
     const result = await response.json();
-    console.log('Delete teacher response:', result);
 
     if (!response.ok) {
       console.error('Delete teacher failed:', result.error);
@@ -173,11 +166,6 @@ export async function deleteTeacher(teacherId: string) {
     return { data: result, error: null };
   } catch (error: any) {
     console.error('Error calling deleteTeacher API:', error);
-    console.error('Error details:', {
-      message: error.message,
-      name: error.name,
-      stack: error.stack,
-    });
     return { data: null, error: error.message || 'Failed to delete teacher' };
   }
 }

--- a/src/admin/components/InviteModal.tsx
+++ b/src/admin/components/InviteModal.tsx
@@ -61,22 +61,17 @@ export default function InviteModal({
 
   // Check if user exists using secure API route
   const handleSend = async () => {
-    setTouched(true); // Mark field as touched when attempting to send
-    console.log('Sending invitation to:', email, 'as role:', role);
-    console.log('Cloud Functions URL:', CLOUD_FUNCTIONS.checkUserEmail);
+    setTouched(true);
     setLoading(true);
     setError('');
     setSuccess('');
     try {
-      // Use Firebase Cloud Function
-      console.log('Checking if user exists...');
       const response = await fetch(CLOUD_FUNCTIONS.checkUserEmail, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email }),
       });
       const result = await response.json();
-      console.log('checkUserEmail response:', { status: response.status, result });
 
       if (!response.ok) {
         setLoading(false);
@@ -90,7 +85,6 @@ export default function InviteModal({
       }
 
       // Check if there's already a pending invitation for this email
-      console.log('Checking for existing pending invitations...');
       const { data: existingPendingInvites } = await getDocuments(
         'pending_invitations',
         buildConstraints({
@@ -111,8 +105,6 @@ export default function InviteModal({
       // For teachers, create or update pending invitation record in Firestore
       if (role === 'teacher') {
         try {
-          console.log('Checking for existing pending teacher invitation...');
-          // Check if a pending invitation already exists for this email
           const { data: existingInvitations } = await getDocuments(
             'pending_invitations',
             buildConstraints({
@@ -124,18 +116,13 @@ export default function InviteModal({
           const invitationCode = `${Date.now()}-${Math.random().toString(36).substring(2, 15)}`;
 
           if (existingInvitations && existingInvitations.length > 0) {
-            // Update existing invitation
             const existingInvite = existingInvitations[0];
-            console.log('Updating existing pending teacher invitation:', existingInvite.id);
             await updateDocument('pending_invitations', existingInvite.id, {
               status: 'pending',
               invited_at: Timestamp.now(),
               invitation_code: invitationCode,
             });
-            console.log('Pending teacher record updated with code:', invitationCode);
           } else {
-            // Create new invitation
-            console.log('Creating new pending teacher record...');
             await addDoc(collection(db, 'pending_invitations'), {
               email,
               role: 'teacher',
@@ -143,15 +130,10 @@ export default function InviteModal({
               invited_at: Timestamp.now(),
               invitation_code: invitationCode,
             });
-            console.log('Pending teacher record created with code:', invitationCode);
           }
 
-          // Generate signup URL with invitation code
           const signupUrl = `${window.location.origin}/signup?invite=${invitationCode}`;
-          console.log('Generated signup URL:', signupUrl);
 
-          // Send invitation email via Firebase Cloud Function
-          console.log('Sending invitation email...');
           const inviteResponse = await fetch(CLOUD_FUNCTIONS.sendInvite, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -163,10 +145,6 @@ export default function InviteModal({
           });
 
           const inviteResult = await inviteResponse.json();
-          console.log('sendInvite response:', {
-            status: inviteResponse.status,
-            result: inviteResult,
-          });
 
           if (!inviteResponse.ok) {
             setLoading(false);
@@ -198,19 +176,14 @@ export default function InviteModal({
           const invitationCode = `${Date.now()}-${Math.random().toString(36).substring(2, 15)}`;
 
           if (existingInvitations && existingInvitations.length > 0) {
-            // Update existing invitation
             const existingInvite = existingInvitations[0];
-            console.log('Updating existing pending student invitation:', existingInvite.id);
             await updateDocument('pending_invitations', existingInvite.id, {
               status: 'pending',
               invited_at: Timestamp.now(),
               teacher_id: teacherId || null,
               invitation_code: invitationCode,
             });
-            console.log('Pending student record updated with code:', invitationCode);
           } else {
-            // Create new invitation
-            console.log('Creating new pending student record...');
             await addDoc(collection(db, 'pending_invitations'), {
               email,
               role: 'student',
@@ -219,15 +192,10 @@ export default function InviteModal({
               teacher_id: teacherId || null,
               invitation_code: invitationCode,
             });
-            console.log('Pending student record created with code:', invitationCode);
           }
 
-          // Generate signup URL with invitation code
           const signupUrl = `${window.location.origin}/signup?invite=${invitationCode}`;
-          console.log('Generated signup URL:', signupUrl);
 
-          // Send invitation email via Firebase Cloud Function
-          console.log('Sending invitation email...');
           const inviteResponse = await fetch(CLOUD_FUNCTIONS.sendInvite, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -239,17 +207,12 @@ export default function InviteModal({
           });
 
           const inviteResult = await inviteResponse.json();
-          console.log('sendInvite response:', {
-            status: inviteResponse.status,
-            result: inviteResult,
-          });
 
           if (!inviteResponse.ok) {
             setLoading(false);
             const errorMessage = inviteResult.details
               ? `${inviteResult.error}: ${inviteResult.details}`
               : inviteResult.error || 'Failed to send invitation. Please try again.';
-            console.error('Invitation failed:', errorMessage);
             setError(errorMessage);
             return;
           }
@@ -263,10 +226,7 @@ export default function InviteModal({
         // Fallback for other roles (if any)
         // Generate signup URL with role and metadata
         const signupUrl = `${window.location.origin}/signup?role=${role}${role === 'student' && teacherId ? `&teacher=${teacherId}` : ''}`;
-        console.log('Generated signup URL:', signupUrl);
 
-        // Send invitation email via Firebase Cloud Function
-        console.log('Sending invitation email...');
         const inviteResponse = await fetch(CLOUD_FUNCTIONS.sendInvite, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -278,10 +238,6 @@ export default function InviteModal({
         });
 
         const inviteResult = await inviteResponse.json();
-        console.log('sendInvite response:', {
-          status: inviteResponse.status,
-          result: inviteResult,
-        });
 
         if (!inviteResponse.ok) {
           setLoading(false);
@@ -313,20 +269,13 @@ export default function InviteModal({
       }
     } catch (err) {
       console.error('Exception in handleSend:', err);
-      console.error('Error details:', {
-        message: err instanceof Error ? err.message : String(err),
-        name: err instanceof Error ? err.name : 'Unknown',
-        stack: err instanceof Error ? err.stack : undefined,
-      });
       setLoading(false);
 
       let errorMessage = 'Error sending invitation. Please try again.';
 
       if (err instanceof TypeError && err.message.includes('fetch')) {
         errorMessage =
-          'Cannot connect to server. Make sure Firebase emulators are running (pnpm firebase:emulators).';
-        console.error('⚠️  Fetch failed - Cloud Functions URL:', CLOUD_FUNCTIONS.checkUserEmail);
-        console.error('⚠️  Make sure Firebase emulators are running: pnpm firebase:emulators');
+          'Cannot connect to server. Make sure Firebase emulators are running (pnpm firebase:emulators)';
       } else if (err instanceof Error) {
         errorMessage = `Error: ${err.message}`;
       }

--- a/src/admin/hooks/useTeachers.ts
+++ b/src/admin/hooks/useTeachers.ts
@@ -87,10 +87,6 @@ export function useTeachers(showAlert: (message: string, title: string) => void)
     // Fetch active teachers
     const { data, error } = await fetchTeachers();
 
-    console.log('Fetching teachers - Data:', data);
-    console.log('Fetching teachers - Error:', error);
-    console.log('Fetching teachers - Count:', data?.length);
-
     let activeTeachers: Teacher[] = [];
 
     if (error) {
@@ -172,34 +168,25 @@ export function useTeachers(showAlert: (message: string, title: string) => void)
     closeConfirm();
 
     setDeleting(true);
-    console.log(`Deleting ${type}:`, id, name);
 
     let data, error;
     if (type === 'teacher') {
       // Check if this is a pending invitation
       const teacher = teachers.find((t) => t.id === id);
       if (teacher?.status === 'pending') {
-        // Delete from pending_invitations collection
-        console.log('Deleting pending invitation:', id);
         const result = await deleteDocument('pending_invitations', id);
         error = result.error;
         data = result.data;
-        console.log('Pending invitation delete result:', { data, error });
       } else {
-        // Delete active teacher via Cloud Function
-        console.log('Deleting active teacher via Cloud Function:', id);
         const result = await deleteTeacher(id);
         data = result.data;
         error = result.error;
-        console.log('Active teacher delete result:', { data, error });
       }
     } else {
       const result = await deleteStudent(id);
       data = result.data;
       error = result.error;
     }
-
-    console.log(`Delete ${type} - Full response:`, { data, error });
 
     if (error) {
       console.error(`Error deleting ${type}:`, error);
@@ -209,8 +196,6 @@ export function useTeachers(showAlert: (message: string, title: string) => void)
       return;
     }
 
-    // Verify the deletion actually worked before updating UI
-    console.log('Verifying deletion...');
     const collection =
       type === 'teacher'
         ? teachers.find((t) => t.id === id)?.status === 'pending'
@@ -221,8 +206,7 @@ export function useTeachers(showAlert: (message: string, title: string) => void)
     const verifyResult = await getDocument(collection, id);
 
     if (verifyResult.data) {
-      // Document still exists - deletion failed
-      console.error(`${type} still exists after deletion attempt:`, verifyResult.data);
+      // Document still exists — deletion failed
       showToast(`Failed to delete ${type}: Record still exists in database`, 'error');
       showAlert(
         `Failed to delete ${type}: The deletion did not complete. Please try again.`,
@@ -232,10 +216,8 @@ export function useTeachers(showAlert: (message: string, title: string) => void)
       return;
     }
 
-    console.log('Delete verified successful, removing from UI...');
     showToast(`${name} has been deleted successfully`);
 
-    // Remove the deleted teacher/student from the local state
     if (type === 'teacher') {
       setTeachers((prevTeachers) => prevTeachers.filter((t) => t.id !== id));
     } else {

--- a/src/components/CommentThread/CommentThread.tsx
+++ b/src/components/CommentThread/CommentThread.tsx
@@ -65,16 +65,12 @@ const CommentThread = forwardRef<CommentThreadHandle, CommentThreadProps>(functi
         eqFilter.step_number = stepNumber;
       }
 
-      console.log('CommentThread: fetching comments for', { projectId, stepNumber, eqFilter });
-
       const { data, error } = await getDocuments(
         'step_comments',
         buildConstraints({
           eq: eqFilter,
         })
       );
-
-      console.log('CommentThread: fetch result', { data, error });
 
       if (error) {
         console.error('Error fetching comments:', error);

--- a/src/components/CreateProject/hooks/useHandlers.ts
+++ b/src/components/CreateProject/hooks/useHandlers.ts
@@ -48,10 +48,6 @@ export function useCreateProjectHandlers(data: any) {
 
     const dueDates = generateDueDates();
 
-    // Log the data being inserted for debugging
-    console.log('Creating project with user ID:', userData.id);
-    console.log('User data:', userData);
-
     const projectData = {
       student_id: userData.id,
       email: userData.email,
@@ -87,7 +83,6 @@ export function useCreateProjectHandlers(data: any) {
         'Error'
       );
     } else {
-      console.log('Project created:', insertData);
       showAlert('Project created successfully!', 'Success');
       navigate('/student/dashboard');
     }

--- a/src/components/Login/hooks/useHandlers.ts
+++ b/src/components/Login/hooks/useHandlers.ts
@@ -46,7 +46,6 @@ export function useLoginHandlers(data: LoginData): LoginHandlers {
         return;
       }
 
-      console.log('User role:', role); // Debug log
 
       if (role === 'student') {
         // Check if student has any projects

--- a/src/components/ResetPassword/hooks/useHandlers.ts
+++ b/src/components/ResetPassword/hooks/useHandlers.ts
@@ -14,7 +14,7 @@ export function useResetPasswordHandlers(data: any) {
       // Verify the reset code is valid
       verifyPasswordResetCode(auth, oobCode)
         .then(() => {
-          console.log('Password reset code verified');
+          // Password reset code verified successfully
         })
         .catch((error) => {
           console.error('Invalid or expired reset code:', error);

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -50,9 +50,6 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
             setCurrentTheme(data.theme as ThemeName);
           }
         } else {
-          // Document doesn't exist - create it with default theme
-          console.log('Settings document not found, will be created on first theme change');
-          // Use default theme
           setCurrentTheme('midnight');
         }
         setLoading(false);
@@ -61,7 +58,6 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
         console.error('Error fetching theme:', error);
         // If permissions error, just use default theme
         if (error.code === 'permission-denied') {
-          console.log('No permission to read settings, using default theme');
           setCurrentTheme('midnight');
         }
         setLoading(false);

--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -12,12 +12,6 @@ const firebaseConfig = {
   appId: import.meta.env.VITE_FIREBASE_APP_ID,
 };
 
-// Debug: Log config (remove in production)
-console.log('Firebase Config:', {
-  ...firebaseConfig,
-  apiKey: firebaseConfig.apiKey ? `${firebaseConfig.apiKey.substring(0, 10)}...` : 'MISSING',
-});
-
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);
 

--- a/src/student/components/Dashboard/Dashboard.tsx
+++ b/src/student/components/Dashboard/Dashboard.tsx
@@ -16,6 +16,7 @@ import {
   AppBar,
   Toolbar,
   Chip,
+  Alert,
 } from '@mui/material';
 import {
   Edit as EditIcon,
@@ -67,6 +68,7 @@ export default function StudentDashboard() {
     navigate,
     alertState,
     closeAlert,
+    allStepsSubmitted,
   } = data;
 
   const {
@@ -264,6 +266,18 @@ export default function StudentDashboard() {
             <Typography variant="h4" component="h2">
               {userProfile.first_name} {userProfile.last_name}'s Project
             </Typography>
+
+            {allStepsSubmitted && (
+              <Alert severity="success" icon={<CheckCircleIcon />}>
+                <Typography variant="body1" fontWeight={600}>
+                  All steps submitted!
+                </Typography>
+                <Typography variant="body2">
+                  Your project is complete and under review. Your teacher will review each step and
+                  provide feedback shortly.
+                </Typography>
+              </Alert>
+            )}
 
             {project && (
               <Paper sx={{ p: 3 }}>

--- a/src/student/components/Dashboard/hooks/useData.ts
+++ b/src/student/components/Dashboard/hooks/useData.ts
@@ -65,6 +65,13 @@ export function useDashboardData() {
     fetchUserAndProfile();
   }, [navigate]);
 
+  const allStepsSubmitted =
+    !!project &&
+    [1, 2, 3, 4, 5].every(n => {
+      const status = (project as any)[`step${n}_status`];
+      return status === 'Submitted' || status === 'Approved';
+    });
+
   return {
     user,
     userProfile,
@@ -82,5 +89,6 @@ export function useDashboardData() {
     alertState,
     showAlert,
     closeAlert,
+    allStepsSubmitted,
   };
 }

--- a/src/student/components/Dashboard/hooks/useData.ts
+++ b/src/student/components/Dashboard/hooks/useData.ts
@@ -34,7 +34,6 @@ export function useDashboardData() {
         };
 
         setUserProfile(profile);
-        console.log('User loaded:', currentUser.email, profile); // Debug log
 
         // Fetch project for the student
         const { data: projectData, error: projectError } = await getDocuments(

--- a/src/student/components/Step1Upload/Step1Upload.tsx
+++ b/src/student/components/Step1Upload/Step1Upload.tsx
@@ -9,8 +9,6 @@ import {
   LinearProgress,
   Tooltip,
 } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
-import React, { useState, useRef } from 'react';
 import { useStep1UploadData } from './hooks/useData';
 import { useStep1UploadHandlers } from './hooks/useHandlers';
 import SharedHeader from '../SharedHeader/SharedHeader';
@@ -20,8 +18,8 @@ import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 
 export default function Step1Upload() {
-  const navigate = useNavigate();
   const {
+    navigate,
     file,
     setFile,
     uploading,
@@ -35,48 +33,33 @@ export default function Step1Upload() {
     setStatus,
     projectId,
     loading,
-  } = useStep1UploadData(navigate);
+    isDragging,
+    setIsDragging,
+    dragCounterRef,
+    justDroppedRef,
+  } = useStep1UploadData();
 
-  const { handleFileChange, handleUpload } = useStep1UploadHandlers({
+  const {
+    handleFileChange,
+    handleUpload,
+    handleDragEnter,
+    handleDragLeave,
+    handleDragOver,
+    handleDragEnd,
+    handleDrop,
+    handleDropZoneClick,
+  } = useStep1UploadHandlers({
     projectId,
     setFile,
     setUploading,
     setErrorMsg,
     setSuccess,
     setStatus,
+    setIsDragging,
+    dragCounterRef,
+    justDroppedRef,
   });
 
-  const [isDragging, setIsDragging] = useState(false);
-  const dragCounterRef = useRef(0);
-  const justDroppedRef = useRef(false);
-
-  const handleDragEnter = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current++;
-    setIsDragging(true);
-  };
-  const handleDragLeave = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current--;
-    if (dragCounterRef.current === 0) setIsDragging(false);
-  };
-  const handleDragOver = (e: React.DragEvent) => {
-    e.preventDefault();
-  };
-  const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current = 0;
-    setIsDragging(false);
-    justDroppedRef.current = true;
-    setTimeout(() => {
-      justDroppedRef.current = false;
-    }, 300);
-    const dropped = e.dataTransfer.files[0];
-    if (!dropped) return;
-    handleFileChange({ target: { files: [dropped], value: '' } } as any);
-  };
-
-  console.log('Step1Upload render - projectId:', projectId, 'loading:', loading, 'file:', file);
 
   return (
     <Box sx={{ minHeight: '100vh', bgcolor: 'background.default' }}>
@@ -188,16 +171,11 @@ export default function Step1Upload() {
                   bgcolor: file ? 'primary.dark' : 'action.hover',
                 },
               }}
-              onClick={() => {
-                if (!justDroppedRef.current) document.getElementById('file-input')?.click();
-              }}
+              onClick={handleDropZoneClick}
               onDragEnter={handleDragEnter}
               onDragOver={handleDragOver}
               onDragLeave={handleDragLeave}
-              onDragEnd={() => {
-                dragCounterRef.current = 0;
-                setIsDragging(false);
-              }}
+              onDragEnd={handleDragEnd}
               onDrop={handleDrop}
             >
               <input

--- a/src/student/components/Step1Upload/hooks/useData.ts
+++ b/src/student/components/Step1Upload/hooks/useData.ts
@@ -1,8 +1,13 @@
-import { useState, useEffect } from 'react';
+import { MutableRefObject, useRef, useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { auth } from '../../../../firebaseConfig';
 import { getDocuments, buildConstraints } from '../../../../utils/firebaseHelpers';
 
-export function useStep1UploadData(navigate: any) {
+export function useStep1UploadData() {
+  const navigate = useNavigate();
+  const [isDragging, setIsDragging] = useState(false);
+  const dragCounterRef: MutableRefObject<number> = useRef(0);
+  const justDroppedRef: MutableRefObject<boolean> = useRef(false);
   const [file, setFile] = useState(null);
   const [uploading, setUploading] = useState(false);
   const [success, setSuccess] = useState(false);
@@ -28,12 +33,6 @@ export function useStep1UploadData(navigate: any) {
           buildConstraints({ eq: { student_id: user.uid }, limit: 1 })
         );
 
-        console.log('Step1Upload - Project fetch result:', {
-          projectDataArray,
-          projectError,
-          hasData: !!(projectDataArray as any[])?.length,
-        });
-
         if (projectError) {
           console.error('Error fetching project:', projectError.message);
           setErrorMsg('Error loading project data: ' + projectError.message);
@@ -51,9 +50,6 @@ export function useStep1UploadData(navigate: any) {
         const projectData = (projectDataArray as any[])[0];
         // Use 'id' field which is the document ID in Firestore
         const currentProjectId = projectData.id;
-
-        console.log('Step1Upload - Project data:', projectData);
-        console.log('Step1Upload - Setting projectId:', currentProjectId);
 
         if (!currentProjectId) {
           console.error('Step1Upload - project id is missing from project data!');
@@ -96,6 +92,11 @@ export function useStep1UploadData(navigate: any) {
   }, [navigate]);
 
   return {
+    navigate,
+    isDragging,
+    setIsDragging,
+    dragCounterRef,
+    justDroppedRef,
     file,
     setFile,
     uploading,

--- a/src/student/components/Step1Upload/hooks/useHandlers.ts
+++ b/src/student/components/Step1Upload/hooks/useHandlers.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import React, { useCallback, MutableRefObject } from 'react';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import { auth, storage } from '../../../../firebaseConfig';
 import { createDocument, getDocument, updateDocument } from '../../../../utils/firebaseHelpers';
@@ -11,6 +11,19 @@ export function useStep1UploadHandlers({
   setErrorMsg,
   setSuccess,
   setStatus,
+  setIsDragging,
+  dragCounterRef,
+  justDroppedRef,
+}: {
+  projectId: string | null
+  setFile: (f: any) => void
+  setUploading: (v: boolean) => void
+  setErrorMsg: (msg: string) => void
+  setSuccess: (v: boolean) => void
+  setStatus: (s: string) => void
+  setIsDragging: (v: boolean) => void
+  dragCounterRef: MutableRefObject<number>
+  justDroppedRef: MutableRefObject<boolean>
 }) {
   const handleFileChange = useCallback(
     async (e) => {
@@ -38,7 +51,6 @@ export function useStep1UploadHandlers({
 
   const handleUpload = useCallback(
     async (file) => {
-      console.log('Step1Upload - handleUpload called with projectId:', projectId);
 
       if (!projectId) {
         setErrorMsg('Project not loaded. Please try refreshing the page.');
@@ -79,12 +91,6 @@ export function useStep1UploadHandlers({
           throw new Error('Unable to verify project ownership. Please try again.');
         }
 
-        console.log('Attempting to insert submission:', {
-          project_id: projectId,
-          step_number: 1,
-          file_url: fileUrl,
-        });
-
         const { error: insertError } = await createDocument('submissions', {
           project_id: projectId,
           step_number: 1,
@@ -117,8 +123,50 @@ export function useStep1UploadHandlers({
     [projectId, setErrorMsg, setUploading, setSuccess, setStatus, setFile]
   );
 
+  const handleDragEnter = useCallback((e: React.DragEvent<HTMLElement>) => {
+    e.preventDefault();
+    dragCounterRef.current++;
+    setIsDragging(true);
+  }, [dragCounterRef, setIsDragging]);
+
+  const handleDragLeave = useCallback((e: React.DragEvent<HTMLElement>) => {
+    e.preventDefault();
+    dragCounterRef.current--;
+    if (dragCounterRef.current === 0) setIsDragging(false);
+  }, [dragCounterRef, setIsDragging]);
+
+  const handleDragOver = useCallback((e: React.DragEvent<HTMLElement>) => {
+    e.preventDefault();
+  }, []);
+
+  const handleDragEnd = useCallback(() => {
+    dragCounterRef.current = 0;
+    setIsDragging(false);
+  }, [dragCounterRef, setIsDragging]);
+
+  const handleDrop = useCallback((e: React.DragEvent<HTMLElement>) => {
+    e.preventDefault();
+    dragCounterRef.current = 0;
+    setIsDragging(false);
+    justDroppedRef.current = true;
+    setTimeout(() => { justDroppedRef.current = false; }, 300);
+    const dropped = e.dataTransfer.files[0];
+    if (!dropped) return;
+    handleFileChange({ target: { files: [dropped], value: '' } } as any);
+  }, [dragCounterRef, setIsDragging, justDroppedRef, handleFileChange]);
+
+  const handleDropZoneClick = useCallback(() => {
+    if (!justDroppedRef.current) document.getElementById('file-input')?.click();
+  }, [justDroppedRef]);
+
   return {
     handleFileChange,
     handleUpload,
+    handleDragEnter,
+    handleDragLeave,
+    handleDragOver,
+    handleDragEnd,
+    handleDrop,
+    handleDropZoneClick,
   };
 }

--- a/src/student/components/Step2Upload/Step2Upload.tsx
+++ b/src/student/components/Step2Upload/Step2Upload.tsx
@@ -9,8 +9,6 @@ import {
   LinearProgress,
   Tooltip,
 } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
-import React, { useState, useRef } from 'react';
 import { useStep2UploadData } from './hooks/useData';
 import { useStep2UploadHandlers } from './hooks/useHandlers';
 import SharedHeader from '../SharedHeader/SharedHeader';
@@ -20,8 +18,8 @@ import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 
 export default function Step2Upload() {
-  const navigate = useNavigate();
   const {
+    navigate,
     file,
     setFile,
     uploading,
@@ -33,46 +31,32 @@ export default function Step2Upload() {
     status,
     setStatus,
     projectId,
-  } = useStep2UploadData(navigate);
+    isDragging,
+    setIsDragging,
+    dragCounterRef,
+    justDroppedRef,
+  } = useStep2UploadData();
 
-  const { handleFileChange, handleUpload } = useStep2UploadHandlers({
+  const {
+    handleFileChange,
+    handleUpload,
+    handleDragEnter,
+    handleDragLeave,
+    handleDragOver,
+    handleDragEnd,
+    handleDrop,
+    handleDropZoneClick,
+  } = useStep2UploadHandlers({
     projectId,
     setFile,
     setUploading,
     setErrorMsg,
     setSuccess,
     setStatus,
+    setIsDragging,
+    dragCounterRef,
+    justDroppedRef,
   });
-
-  const [isDragging, setIsDragging] = useState(false);
-  const dragCounterRef = useRef(0);
-  const justDroppedRef = useRef(false);
-
-  const handleDragEnter = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current++;
-    setIsDragging(true);
-  };
-  const handleDragLeave = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current--;
-    if (dragCounterRef.current === 0) setIsDragging(false);
-  };
-  const handleDragOver = (e: React.DragEvent) => {
-    e.preventDefault();
-  };
-  const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current = 0;
-    setIsDragging(false);
-    justDroppedRef.current = true;
-    setTimeout(() => {
-      justDroppedRef.current = false;
-    }, 300);
-    const dropped = e.dataTransfer.files[0];
-    if (!dropped) return;
-    handleFileChange({ target: { files: [dropped], value: '' } } as any);
-  };
 
   return (
     <Box sx={{ minHeight: '100vh', bgcolor: 'background.default' }}>
@@ -173,16 +157,11 @@ export default function Step2Upload() {
                 cursor: 'pointer',
                 '&:hover': { borderColor: 'primary.light', bgcolor: file ? 'primary.dark' : 'action.hover' },
               }}
-              onClick={() => {
-                if (!justDroppedRef.current) document.getElementById('file-input-s2')?.click();
-              }}
+              onClick={handleDropZoneClick}
               onDragEnter={handleDragEnter}
               onDragOver={handleDragOver}
               onDragLeave={handleDragLeave}
-              onDragEnd={() => {
-                dragCounterRef.current = 0;
-                setIsDragging(false);
-              }}
+              onDragEnd={handleDragEnd}
               onDrop={handleDrop}
             >
               <input

--- a/src/student/components/Step2Upload/hooks/useData.ts
+++ b/src/student/components/Step2Upload/hooks/useData.ts
@@ -1,8 +1,13 @@
-import { useState, useEffect } from 'react';
+import { MutableRefObject, useRef, useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { auth } from '../../../../firebaseConfig';
 import { getDocuments, buildConstraints } from '../../../../utils/firebaseHelpers';
 
-export function useStep2UploadData(navigate: any) {
+export function useStep2UploadData() {
+  const navigate = useNavigate();
+  const [isDragging, setIsDragging] = useState(false);
+  const dragCounterRef: MutableRefObject<number> = useRef(0);
+  const justDroppedRef: MutableRefObject<boolean> = useRef(false);
   const [file, setFile] = useState(null);
   const [uploading, setUploading] = useState(false);
   const [success, setSuccess] = useState(false);
@@ -65,6 +70,11 @@ export function useStep2UploadData(navigate: any) {
   }, [navigate]);
 
   return {
+    navigate,
+    isDragging,
+    setIsDragging,
+    dragCounterRef,
+    justDroppedRef,
     file,
     setFile,
     uploading,

--- a/src/student/components/Step2Upload/hooks/useHandlers.ts
+++ b/src/student/components/Step2Upload/hooks/useHandlers.ts
@@ -1,3 +1,4 @@
+import React, { MutableRefObject } from 'react';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import { auth, storage } from '../../../../firebaseConfig';
 import { createDocument, updateDocument } from '../../../../utils/firebaseHelpers';
@@ -10,6 +11,19 @@ export function useStep2UploadHandlers({
   setErrorMsg,
   setSuccess,
   setStatus,
+  setIsDragging,
+  dragCounterRef,
+  justDroppedRef,
+}: {
+  projectId: string | null
+  setFile: (f: any) => void
+  setUploading: (v: boolean) => void
+  setErrorMsg: (msg: string) => void
+  setSuccess: (v: boolean) => void
+  setStatus: (s: string) => void
+  setIsDragging: (v: boolean) => void
+  dragCounterRef: MutableRefObject<number>
+  justDroppedRef: MutableRefObject<boolean>
 }) {
   const handleFileChange = async (e) => {
     const selected = e.target.files[0];
@@ -85,8 +99,50 @@ export function useStep2UploadHandlers({
     }
   };
 
+  const handleDragEnter = (e: React.DragEvent<HTMLElement>) => {
+    e.preventDefault();
+    dragCounterRef.current++;
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent<HTMLElement>) => {
+    e.preventDefault();
+    dragCounterRef.current--;
+    if (dragCounterRef.current === 0) setIsDragging(false);
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLElement>) => {
+    e.preventDefault();
+  };
+
+  const handleDragEnd = () => {
+    dragCounterRef.current = 0;
+    setIsDragging(false);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLElement>) => {
+    e.preventDefault();
+    dragCounterRef.current = 0;
+    setIsDragging(false);
+    justDroppedRef.current = true;
+    setTimeout(() => { justDroppedRef.current = false; }, 300);
+    const dropped = e.dataTransfer.files[0];
+    if (!dropped) return;
+    handleFileChange({ target: { files: [dropped], value: '' } } as any);
+  };
+
+  const handleDropZoneClick = () => {
+    if (!justDroppedRef.current) document.getElementById('file-input-s2')?.click();
+  };
+
   return {
     handleFileChange,
     handleUpload,
+    handleDragEnter,
+    handleDragLeave,
+    handleDragOver,
+    handleDragEnd,
+    handleDrop,
+    handleDropZoneClick,
   };
 }

--- a/src/student/components/Step3Upload/Step3Upload.tsx
+++ b/src/student/components/Step3Upload/Step3Upload.tsx
@@ -9,8 +9,6 @@ import {
   LinearProgress,
   Tooltip,
 } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
-import React, { useState, useRef } from 'react';
 import { useStep3UploadData } from './hooks/useData';
 import { useStep3UploadHandlers } from './hooks/useHandlers';
 import SharedHeader from '../SharedHeader/SharedHeader';
@@ -20,8 +18,8 @@ import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 
 export default function Step3Upload() {
-  const navigate = useNavigate();
   const {
+    navigate,
     file,
     setFile,
     uploading,
@@ -33,46 +31,32 @@ export default function Step3Upload() {
     status,
     setStatus,
     projectId,
-  } = useStep3UploadData(navigate);
+    isDragging,
+    setIsDragging,
+    dragCounterRef,
+    justDroppedRef,
+  } = useStep3UploadData();
 
-  const { handleFileChange, handleUpload } = useStep3UploadHandlers({
+  const {
+    handleFileChange,
+    handleUpload,
+    handleDragEnter,
+    handleDragLeave,
+    handleDragOver,
+    handleDragEnd,
+    handleDrop,
+    handleDropZoneClick,
+  } = useStep3UploadHandlers({
     projectId,
     setFile,
     setUploading,
     setErrorMsg,
     setSuccess,
     setStatus,
+    setIsDragging,
+    dragCounterRef,
+    justDroppedRef,
   });
-
-  const [isDragging, setIsDragging] = useState(false);
-  const dragCounterRef = useRef(0);
-  const justDroppedRef = useRef(false);
-
-  const handleDragEnter = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current++;
-    setIsDragging(true);
-  };
-  const handleDragLeave = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current--;
-    if (dragCounterRef.current === 0) setIsDragging(false);
-  };
-  const handleDragOver = (e: React.DragEvent) => {
-    e.preventDefault();
-  };
-  const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current = 0;
-    setIsDragging(false);
-    justDroppedRef.current = true;
-    setTimeout(() => {
-      justDroppedRef.current = false;
-    }, 300);
-    const dropped = e.dataTransfer.files[0];
-    if (!dropped) return;
-    handleFileChange({ target: { files: [dropped], value: '' } } as any);
-  };
 
   return (
     <Box sx={{ minHeight: '100vh', bgcolor: 'background.default' }}>
@@ -173,16 +157,11 @@ export default function Step3Upload() {
                 cursor: 'pointer',
                 '&:hover': { borderColor: 'primary.light', bgcolor: file ? 'primary.dark' : 'action.hover' },
               }}
-              onClick={() => {
-                if (!justDroppedRef.current) document.getElementById('file-input-s3')?.click();
-              }}
+              onClick={handleDropZoneClick}
               onDragEnter={handleDragEnter}
               onDragOver={handleDragOver}
               onDragLeave={handleDragLeave}
-              onDragEnd={() => {
-                dragCounterRef.current = 0;
-                setIsDragging(false);
-              }}
+              onDragEnd={handleDragEnd}
               onDrop={handleDrop}
             >
               <input

--- a/src/student/components/Step3Upload/hooks/useData.ts
+++ b/src/student/components/Step3Upload/hooks/useData.ts
@@ -1,8 +1,13 @@
-import { useState, useEffect } from 'react';
+import { MutableRefObject, useRef, useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { auth } from '../../../../firebaseConfig';
 import { getDocuments, buildConstraints } from '../../../../utils/firebaseHelpers';
 
-export function useStep3UploadData(navigate: any) {
+export function useStep3UploadData() {
+  const navigate = useNavigate();
+  const [isDragging, setIsDragging] = useState(false);
+  const dragCounterRef: MutableRefObject<number> = useRef(0);
+  const justDroppedRef: MutableRefObject<boolean> = useRef(false);
   const [file, setFile] = useState(null);
   const [uploading, setUploading] = useState(false);
   const [success, setSuccess] = useState(false);
@@ -65,6 +70,11 @@ export function useStep3UploadData(navigate: any) {
   }, [navigate]);
 
   return {
+    navigate,
+    isDragging,
+    setIsDragging,
+    dragCounterRef,
+    justDroppedRef,
     file,
     setFile,
     uploading,

--- a/src/student/components/Step3Upload/hooks/useHandlers.ts
+++ b/src/student/components/Step3Upload/hooks/useHandlers.ts
@@ -1,3 +1,4 @@
+import React, { MutableRefObject } from 'react';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import { auth, storage } from '../../../../firebaseConfig';
 import { createDocument, updateDocument } from '../../../../utils/firebaseHelpers';
@@ -10,6 +11,19 @@ export function useStep3UploadHandlers({
   setErrorMsg,
   setSuccess,
   setStatus,
+  setIsDragging,
+  dragCounterRef,
+  justDroppedRef,
+}: {
+  projectId: string | null
+  setFile: (f: any) => void
+  setUploading: (v: boolean) => void
+  setErrorMsg: (msg: string) => void
+  setSuccess: (v: boolean) => void
+  setStatus: (s: string) => void
+  setIsDragging: (v: boolean) => void
+  dragCounterRef: MutableRefObject<number>
+  justDroppedRef: MutableRefObject<boolean>
 }) {
   const handleFileChange = async (e) => {
     const selected = e.target.files[0];
@@ -85,8 +99,50 @@ export function useStep3UploadHandlers({
     }
   };
 
+  const handleDragEnter = (e: React.DragEvent<HTMLElement>) => {
+    e.preventDefault();
+    dragCounterRef.current++;
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent<HTMLElement>) => {
+    e.preventDefault();
+    dragCounterRef.current--;
+    if (dragCounterRef.current === 0) setIsDragging(false);
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLElement>) => {
+    e.preventDefault();
+  };
+
+  const handleDragEnd = () => {
+    dragCounterRef.current = 0;
+    setIsDragging(false);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLElement>) => {
+    e.preventDefault();
+    dragCounterRef.current = 0;
+    setIsDragging(false);
+    justDroppedRef.current = true;
+    setTimeout(() => { justDroppedRef.current = false; }, 300);
+    const dropped = e.dataTransfer.files[0];
+    if (!dropped) return;
+    handleFileChange({ target: { files: [dropped], value: '' } } as any);
+  };
+
+  const handleDropZoneClick = () => {
+    if (!justDroppedRef.current) document.getElementById('file-input-s3')?.click();
+  };
+
   return {
     handleFileChange,
     handleUpload,
+    handleDragEnter,
+    handleDragLeave,
+    handleDragOver,
+    handleDragEnd,
+    handleDrop,
+    handleDropZoneClick,
   };
 }

--- a/src/student/components/Step4Upload/Step4Upload.tsx
+++ b/src/student/components/Step4Upload/Step4Upload.tsx
@@ -9,8 +9,6 @@ import {
   LinearProgress,
   Tooltip,
 } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
-import React, { useState, useRef } from 'react';
 import { useStep4UploadData } from './hooks/useData';
 import { useStep4UploadHandlers } from './hooks/useHandlers';
 import SharedHeader from '../SharedHeader/SharedHeader';
@@ -20,8 +18,8 @@ import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 
 export default function Step4Upload() {
-  const navigate = useNavigate();
   const {
+    navigate,
     file,
     setFile,
     uploading,
@@ -33,46 +31,32 @@ export default function Step4Upload() {
     status,
     setStatus,
     projectId,
-  } = useStep4UploadData(navigate);
+    isDragging,
+    setIsDragging,
+    dragCounterRef,
+    justDroppedRef,
+  } = useStep4UploadData();
 
-  const { handleFileChange, handleUpload } = useStep4UploadHandlers({
+  const {
+    handleFileChange,
+    handleUpload,
+    handleDragEnter,
+    handleDragLeave,
+    handleDragOver,
+    handleDragEnd,
+    handleDrop,
+    handleDropZoneClick,
+  } = useStep4UploadHandlers({
     projectId,
     setFile,
     setUploading,
     setErrorMsg,
     setSuccess,
     setStatus,
+    setIsDragging,
+    dragCounterRef,
+    justDroppedRef,
   });
-
-  const [isDragging, setIsDragging] = useState(false);
-  const dragCounterRef = useRef(0);
-  const justDroppedRef = useRef(false);
-
-  const handleDragEnter = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current++;
-    setIsDragging(true);
-  };
-  const handleDragLeave = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current--;
-    if (dragCounterRef.current === 0) setIsDragging(false);
-  };
-  const handleDragOver = (e: React.DragEvent) => {
-    e.preventDefault();
-  };
-  const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current = 0;
-    setIsDragging(false);
-    justDroppedRef.current = true;
-    setTimeout(() => {
-      justDroppedRef.current = false;
-    }, 300);
-    const dropped = e.dataTransfer.files[0];
-    if (!dropped) return;
-    handleFileChange({ target: { files: [dropped], value: '' } } as any);
-  };
 
   return (
     <Box sx={{ minHeight: '100vh', bgcolor: 'background.default' }}>
@@ -173,16 +157,11 @@ export default function Step4Upload() {
                 cursor: 'pointer',
                 '&:hover': { borderColor: 'primary.light', bgcolor: file ? 'primary.dark' : 'action.hover' },
               }}
-              onClick={() => {
-                if (!justDroppedRef.current) document.getElementById('file-input-s4')?.click();
-              }}
+              onClick={handleDropZoneClick}
               onDragEnter={handleDragEnter}
               onDragOver={handleDragOver}
               onDragLeave={handleDragLeave}
-              onDragEnd={() => {
-                dragCounterRef.current = 0;
-                setIsDragging(false);
-              }}
+              onDragEnd={handleDragEnd}
               onDrop={handleDrop}
             >
               <input

--- a/src/student/components/Step4Upload/hooks/useData.ts
+++ b/src/student/components/Step4Upload/hooks/useData.ts
@@ -1,8 +1,13 @@
-import { useState, useEffect } from 'react';
+import { MutableRefObject, useRef, useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { auth } from '../../../../firebaseConfig';
 import { getDocuments, buildConstraints } from '../../../../utils/firebaseHelpers';
 
-export function useStep4UploadData(navigate: any) {
+export function useStep4UploadData() {
+  const navigate = useNavigate();
+  const [isDragging, setIsDragging] = useState(false);
+  const dragCounterRef: MutableRefObject<number> = useRef(0);
+  const justDroppedRef: MutableRefObject<boolean> = useRef(false);
   const [file, setFile] = useState(null);
   const [uploading, setUploading] = useState(false);
   const [success, setSuccess] = useState(false);
@@ -65,6 +70,11 @@ export function useStep4UploadData(navigate: any) {
   }, [navigate]);
 
   return {
+    navigate,
+    isDragging,
+    setIsDragging,
+    dragCounterRef,
+    justDroppedRef,
     file,
     setFile,
     uploading,

--- a/src/student/components/Step4Upload/hooks/useHandlers.ts
+++ b/src/student/components/Step4Upload/hooks/useHandlers.ts
@@ -1,3 +1,4 @@
+import React, { MutableRefObject } from 'react';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import { auth, storage } from '../../../../firebaseConfig';
 import { createDocument, updateDocument } from '../../../../utils/firebaseHelpers';
@@ -10,6 +11,19 @@ export function useStep4UploadHandlers({
   setErrorMsg,
   setSuccess,
   setStatus,
+  setIsDragging,
+  dragCounterRef,
+  justDroppedRef,
+}: {
+  projectId: string | null
+  setFile: (f: any) => void
+  setUploading: (v: boolean) => void
+  setErrorMsg: (msg: string) => void
+  setSuccess: (v: boolean) => void
+  setStatus: (s: string) => void
+  setIsDragging: (v: boolean) => void
+  dragCounterRef: MutableRefObject<number>
+  justDroppedRef: MutableRefObject<boolean>
 }) {
   const handleFileChange = async (e) => {
     const selected = e.target.files[0];
@@ -85,8 +99,50 @@ export function useStep4UploadHandlers({
     }
   };
 
+  const handleDragEnter = (e: React.DragEvent<HTMLElement>) => {
+    e.preventDefault();
+    dragCounterRef.current++;
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent<HTMLElement>) => {
+    e.preventDefault();
+    dragCounterRef.current--;
+    if (dragCounterRef.current === 0) setIsDragging(false);
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLElement>) => {
+    e.preventDefault();
+  };
+
+  const handleDragEnd = () => {
+    dragCounterRef.current = 0;
+    setIsDragging(false);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLElement>) => {
+    e.preventDefault();
+    dragCounterRef.current = 0;
+    setIsDragging(false);
+    justDroppedRef.current = true;
+    setTimeout(() => { justDroppedRef.current = false; }, 300);
+    const dropped = e.dataTransfer.files[0];
+    if (!dropped) return;
+    handleFileChange({ target: { files: [dropped], value: '' } } as any);
+  };
+
+  const handleDropZoneClick = () => {
+    if (!justDroppedRef.current) document.getElementById('file-input-s4')?.click();
+  };
+
   return {
     handleFileChange,
     handleUpload,
+    handleDragEnter,
+    handleDragLeave,
+    handleDragOver,
+    handleDragEnd,
+    handleDrop,
+    handleDropZoneClick,
   };
 }

--- a/src/student/components/Step5Upload/Step5Upload.tsx
+++ b/src/student/components/Step5Upload/Step5Upload.tsx
@@ -11,8 +11,6 @@ import {
   Link,
   Tooltip,
 } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
-import React, { useState, useRef } from 'react';
 import { useStep5UploadData } from './hooks/useData';
 import { useStep5UploadHandlers } from './hooks/useHandlers';
 import SharedHeader from '../SharedHeader/SharedHeader';
@@ -22,8 +20,8 @@ import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 
 export default function Step5Upload() {
-  const navigate = useNavigate();
   const {
+    navigate,
     file,
     setFile,
     youtubeLink,
@@ -37,46 +35,33 @@ export default function Step5Upload() {
     status,
     setStatus,
     projectId,
-  } = useStep5UploadData(navigate);
+    isDragging,
+    setIsDragging,
+    dragCounterRef,
+    justDroppedRef,
+  } = useStep5UploadData();
 
-  const { handleFileChange, handleYoutubeLinkChange, handleSubmit } = useStep5UploadHandlers({
+  const {
+    handleFileChange,
+    handleYoutubeLinkChange,
+    handleSubmit,
+    handleDragEnter,
+    handleDragLeave,
+    handleDragOver,
+    handleDragEnd,
+    handleDrop,
+    handleDropZoneClick,
+  } = useStep5UploadHandlers({
     projectId,
     setFile,
     setUploading,
     setErrorMsg,
     setSuccess,
     setStatus,
+    setIsDragging,
+    dragCounterRef,
+    justDroppedRef,
   });
-
-  const [isDragging, setIsDragging] = useState(false);
-  const dragCounterRef = useRef(0);
-  const justDroppedRef = useRef(false);
-
-  const handleDragEnter = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current++;
-    setIsDragging(true);
-  };
-  const handleDragLeave = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current--;
-    if (dragCounterRef.current === 0) setIsDragging(false);
-  };
-  const handleDragOver = (e: React.DragEvent) => {
-    e.preventDefault();
-  };
-  const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current = 0;
-    setIsDragging(false);
-    justDroppedRef.current = true;
-    setTimeout(() => {
-      justDroppedRef.current = false;
-    }, 300);
-    const dropped = e.dataTransfer.files[0];
-    if (!dropped) return;
-    handleFileChange({ target: { files: [dropped], value: '' } } as any);
-  };
 
   return (
     <Box sx={{ minHeight: '100vh', bgcolor: 'background.default' }}>
@@ -191,16 +176,11 @@ export default function Step5Upload() {
                   cursor: 'pointer',
                   '&:hover': { borderColor: 'primary.light', bgcolor: file ? 'primary.dark' : 'action.hover' },
                 }}
-                onClick={() => {
-                  if (!justDroppedRef.current) document.getElementById('file-input-s5')?.click();
-                }}
+                onClick={handleDropZoneClick}
                 onDragEnter={handleDragEnter}
                 onDragOver={handleDragOver}
                 onDragLeave={handleDragLeave}
-                onDragEnd={() => {
-                  dragCounterRef.current = 0;
-                  setIsDragging(false);
-                }}
+                onDragEnd={handleDragEnd}
                 onDrop={handleDrop}
               >
                 <input

--- a/src/student/components/Step5Upload/hooks/useData.ts
+++ b/src/student/components/Step5Upload/hooks/useData.ts
@@ -1,8 +1,13 @@
-import { useState, useEffect } from 'react';
+import { MutableRefObject, useRef, useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { auth } from '../../../../firebaseConfig';
-import { getDocument, getDocuments, buildConstraints } from '../../../../utils/firebaseHelpers';
+import { getDocuments, buildConstraints } from '../../../../utils/firebaseHelpers';
 
-export function useStep5UploadData(navigate: any) {
+export function useStep5UploadData() {
+  const navigate = useNavigate();
+  const [isDragging, setIsDragging] = useState(false);
+  const dragCounterRef: MutableRefObject<number> = useRef(0);
+  const justDroppedRef: MutableRefObject<boolean> = useRef(false);
   const [file, setFile] = useState(null);
   const [youtubeLink, setYoutubeLink] = useState('');
   const [uploading, setUploading] = useState(false);
@@ -70,6 +75,11 @@ export function useStep5UploadData(navigate: any) {
   }, [navigate]);
 
   return {
+    navigate,
+    isDragging,
+    setIsDragging,
+    dragCounterRef,
+    justDroppedRef,
     file,
     setFile,
     youtubeLink,

--- a/src/student/components/Step5Upload/hooks/useHandlers.ts
+++ b/src/student/components/Step5Upload/hooks/useHandlers.ts
@@ -1,3 +1,4 @@
+import React, { MutableRefObject } from 'react';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import { auth, storage } from '../../../../firebaseConfig';
 import { createDocument, updateDocument } from '../../../../utils/firebaseHelpers';
@@ -36,6 +37,19 @@ export function useStep5UploadHandlers({
   setErrorMsg,
   setSuccess,
   setStatus,
+  setIsDragging,
+  dragCounterRef,
+  justDroppedRef,
+}: {
+  projectId: string | null
+  setFile: (f: any) => void
+  setUploading: (v: boolean) => void
+  setErrorMsg: (msg: string) => void
+  setSuccess: (v: boolean) => void
+  setStatus: (s: string) => void
+  setIsDragging: (v: boolean) => void
+  dragCounterRef: MutableRefObject<number>
+  justDroppedRef: MutableRefObject<boolean>
 }) {
   const handleFileChange = async (e) => {
     const selected = e.target.files[0];
@@ -128,9 +142,51 @@ export function useStep5UploadHandlers({
     }
   };
 
+  const handleDragEnter = (e: React.DragEvent<HTMLElement>) => {
+    e.preventDefault();
+    dragCounterRef.current++;
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent<HTMLElement>) => {
+    e.preventDefault();
+    dragCounterRef.current--;
+    if (dragCounterRef.current === 0) setIsDragging(false);
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLElement>) => {
+    e.preventDefault();
+  };
+
+  const handleDragEnd = () => {
+    dragCounterRef.current = 0;
+    setIsDragging(false);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLElement>) => {
+    e.preventDefault();
+    dragCounterRef.current = 0;
+    setIsDragging(false);
+    justDroppedRef.current = true;
+    setTimeout(() => { justDroppedRef.current = false; }, 300);
+    const dropped = e.dataTransfer.files[0];
+    if (!dropped) return;
+    handleFileChange({ target: { files: [dropped], value: '' } } as any);
+  };
+
+  const handleDropZoneClick = () => {
+    if (!justDroppedRef.current) document.getElementById('file-input-s5')?.click();
+  };
+
   return {
     handleFileChange,
     handleYoutubeLinkChange,
     handleSubmit,
+    handleDragEnter,
+    handleDragLeave,
+    handleDragOver,
+    handleDragEnd,
+    handleDrop,
+    handleDropZoneClick,
   };
 }

--- a/src/teacher/components/Dashboard/Dashboard.tsx
+++ b/src/teacher/components/Dashboard/Dashboard.tsx
@@ -1,485 +1,305 @@
-import React, { useState } from 'react';
-import EmailIcon from '@mui/icons-material/Email';
-import InviteModal from '../../../admin/components/InviteModal';
-import ImpersonationBanner from '../../../admin/components/ImpersonationBanner';
-import StepSubmissionModal from '../StepSubmissionModal/StepSubmissionModal';
-import StudentsList from './StudentsList';
-import ConfirmDialog from '../../../admin/components/ConfirmDialog';
+import EmailIcon from '@mui/icons-material/Email'
+import InviteModal from '../../../admin/components/InviteModal'
+import ImpersonationBanner from '../../../admin/components/ImpersonationBanner'
+import StepSubmissionModal from '../StepSubmissionModal/StepSubmissionModal'
+import StudentsList from './StudentsList'
+import ConfirmDialog from '../../../admin/components/ConfirmDialog'
 import {
-  getDocuments,
-  buildConstraints,
-  deleteDocument,
-  updateDocument,
-} from '../../../utils/firebaseHelpers';
-import { ref as storageRef, deleteObject } from 'firebase/storage';
-import { storage } from '../../../firebaseConfig';
+    Box,
+    Container,
+    Typography,
+    Button,
+    Paper,
+    Stack,
+    AppBar,
+    Toolbar,
+    Chip,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogContentText,
+    DialogTitle,
+    IconButton,
+    Tooltip,
+} from '@mui/material'
 import {
-  Box,
-  Container,
-  Typography,
-  Button,
-  Paper,
-  Stack,
-  AppBar,
-  Toolbar,
-  Chip,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-  IconButton,
-  Tooltip,
-} from '@mui/material';
-import {
-  Logout as LogoutIcon,
-  Notifications as NotificationsIcon,
-  UnfoldMore as UnfoldMoreIcon,
-  UnfoldLess as UnfoldLessIcon,
-} from '@mui/icons-material';
-import Badge from '@mui/material/Badge';
-import { useDashboardData } from './hooks/useData';
-import { useDashboardHandlers } from './hooks/useHandlers';
-import { useStudents } from './hooks/useStudents';
-import AlertDialog from '../../../components/AlertDialog/AlertDialog';
-import { auth } from '../../../firebaseConfig';
-import orbiliusLogo from '../../../assets/merle-386x386-yellow.svg';
-import { Project } from '../../../types';
+    Logout as LogoutIcon,
+    Notifications as NotificationsIcon,
+    UnfoldMore as UnfoldMoreIcon,
+    UnfoldLess as UnfoldLessIcon,
+} from '@mui/icons-material'
+import Badge from '@mui/material/Badge'
+import { useDashboardData } from './hooks/useData'
+import { useDashboardHandlers } from './hooks/useHandlers'
+import AlertDialog from '../../../components/AlertDialog/AlertDialog'
+import orbiliusLogo from '../../../assets/merle-386x386-yellow.svg'
 
 export default function TeacherDashboard() {
-  const data = useDashboardData();
-  const handlers = useDashboardHandlers(data);
-  const [showInviteModal, setShowInviteModal] = useState(false);
-  const [initialEmail, setInitialEmail] = useState('');
-  const [resendConfirmOpen, setResendConfirmOpen] = useState(false);
-  const [emailToResend, setEmailToResend] = useState('');
-  const [submissionModal, setSubmissionModal] = useState<{
-    open: boolean;
-    projectId: string | null;
-    stepNumber: number | null;
-    project: Project | null;
-  }>({
-    open: false,
-    projectId: null,
-    stepNumber: null,
-    project: null,
-  });
-  const [allStudentsExpanded, setAllStudentsExpanded] = useState(true);
-  const [deleteSubmissionState, setDeleteSubmissionState] = useState<{
-    open: boolean;
-    project: Project | null;
-    stepNumber: number | null;
-    deleting: boolean;
-  }>({ open: false, project: null, stepNumber: null, deleting: false });
+    const data = useDashboardData()
+    const handlers = useDashboardHandlers(data)
 
-  const {
-    user,
-    userProfile,
-    projects,
-    navigate,
-    alertState,
-    showAlert,
-    closeAlert,
-    refreshProjects,
-  } = data;
+    const {
+        user,
+        userProfile,
+        projects,
+        navigate,
+        alertState,
+        closeAlert,
+        showInviteModal,
+        setShowInviteModal,
+        initialEmail,
+        resendConfirmOpen,
+        setResendConfirmOpen,
+        emailToResend,
+        submissionModal,
+        allStudentsExpanded,
+        setAllStudentsExpanded,
+        deleteSubmissionState,
+        setDeleteSubmissionState,
+        effectiveTeacherId,
+        studentsHook,
+        students,
+        projectsNeedingReview,
+        showAlert,
+    } = data
 
-  // Check if admin is impersonating a teacher
-  const impersonatingTeacherId = sessionStorage.getItem('impersonating_teacher_uid');
-  const effectiveTeacherId = impersonatingTeacherId || user?.uid;
+    const {
+        getCurrentStepName,
+        getCurrentStepSubmissionStatus,
+        handleEmailStudent,
+        handleEmailProjectStudent,
+        handleResendInvitation,
+        handleConfirmResend,
+        handleCloseInviteModal,
+        handleLogout,
+        handleStepClick,
+        handleOpenDeleteSubmission,
+        handleDeleteSubmission,
+        handleCloseSubmissionModal,
+    } = handlers
 
-  // Initialize students hook
-  const studentsHook = useStudents(effectiveTeacherId, showAlert, refreshProjects);
-  const students = studentsHook.students;
-
-  // Debug logging
-  console.log('Teacher Dashboard - User ID:', user?.uid);
-  console.log('Teacher Dashboard - Projects:', projects);
-  console.log('Teacher Dashboard - Projects length:', projects?.length);
-
-  // Count projects that need review (have any submitted step)
-  const projectsNeedingReview = projects.filter((project) => {
-    for (let i = 1; i <= 5; i++) {
-      if (project[`step${i}_status`] === 'Submitted') {
-        return true;
-      }
-    }
-    return false;
-  }).length;
-
-  const {
-    getCurrentStepName,
-    getCurrentStepDueDate,
-    getCurrentStepSubmissionStatus,
-    getActionButtonText,
-    handleActionClick,
-  } = handlers;
-
-  const handleEmailStudent = (studentEmail: string) => {
-    const mailtoLink = `mailto:${studentEmail}`;
-    window.open(mailtoLink);
-  };
-
-  const handleEmailProjectStudent = (project: Project) => {
-    const studentEmail = project.student?.email || project.email;
-    const currentStepName = getCurrentStepName(project.current_step);
-
-    if (!studentEmail) {
-      showAlert('Student email not found. Please check the project data.', 'Error');
-      return;
-    }
-
-    const subject = `${project.project_title} - Step ${project.current_step}: ${currentStepName}`;
-
-    const mailtoLink = `mailto:${studentEmail}?subject=${encodeURIComponent(subject)}`;
-    window.open(mailtoLink);
-  };
-
-  const handleCopyTeacherId = () => {
-    navigator.clipboard.writeText(user?.uid);
-    showAlert('Teacher ID copied to clipboard!', 'Success');
-  };
-
-  const handleCopySignupLink = () => {
-    const signupLink = `${window.location.origin}/signup?teacherId=${user?.uid}`;
-    navigator.clipboard.writeText(signupLink);
-    showAlert('Signup link copied to clipboard!', 'Success');
-  };
-
-  const handleResendInvitation = (email: string) => {
-    setEmailToResend(email);
-    setResendConfirmOpen(true);
-  };
-
-  const handleConfirmResend = () => {
-    setResendConfirmOpen(false);
-    setInitialEmail(emailToResend);
-    setShowInviteModal(true);
-  };
-
-  const handleCloseInviteModal = () => {
-    setShowInviteModal(false);
-    setInitialEmail('');
-    // Reload students after sending/resending invitation
-    studentsHook.loadStudents();
-  };
-
-  const handleLogout = async () => {
-    await auth.signOut();
-    navigate('/login');
-  };
-
-  const handleStepClick = (project: Project, stepIndex: number) => {
-    const stepNumber = stepIndex + 1;
-    const stepStatus = project[`step${stepNumber}_status`];
-
-    // Navigate to approval page for submitted or revision-requested steps
-    if (stepStatus === 'Submitted' || stepStatus === 'Revision Requested') {
-      navigate(`/teacher/step-approval/${project.project_id}/${stepNumber}`);
-    }
-    // Open modal for approved steps
-    else if (stepStatus === 'Approved') {
-      setSubmissionModal({
-        open: true,
-        projectId: project.project_id,
-        stepNumber: stepNumber,
-        project: project,
-      });
-    }
-  };
-
-  const handleCloseSubmissionModal = () => {
-    setSubmissionModal({
-      open: false,
-      projectId: null,
-      stepNumber: null,
-      project: null,
-    });
-  };
-
-  const handleOpenDeleteSubmission = (project: Project, stepNumber: number) => {
-    setDeleteSubmissionState({ open: true, project, stepNumber, deleting: false });
-  };
-
-  const handleDeleteSubmission = async () => {
-    const { project, stepNumber } = deleteSubmissionState;
-    if (!project || !stepNumber) return;
-
-    setDeleteSubmissionState((s) => ({ ...s, deleting: true }));
-
-    try {
-      // Find the submission document
-      const { data: submissions } = await getDocuments(
-        'submissions',
-        buildConstraints({ eq: { project_id: project.project_id, step_number: stepNumber } })
-      );
-
-      if (submissions && (submissions as any[]).length > 0) {
-        const submission = (submissions as any[])[0];
-
-        // Delete file from Firebase Storage if present
-        if (submission.file_url) {
-          try {
-            const urlObj = new URL(submission.file_url);
-            const pathMatch = urlObj.pathname.match(/\/o\/(.+?)(\?|$)/);
-            if (pathMatch?.[1]) {
-              const filePath = decodeURIComponent(pathMatch[1]);
-              await deleteObject(storageRef(storage, filePath));
-            }
-          } catch (storageErr) {
-            console.warn('Could not delete storage file:', storageErr);
-          }
-        }
-
-        // Delete the submission document
-        await deleteDocument('submissions', submission.id);
-      }
-
-      // Reset step status on the project
-      const updates: Record<string, any> = {
-        [`step${stepNumber}_status`]: 'Not Started',
-      };
-      // If this step is at or ahead of current_step, roll back current_step
-      if (stepNumber <= project.current_step) {
-        updates.current_step = stepNumber;
-        updates.current_step_status = 'Not Started';
-      }
-      await updateDocument('projects', project.project_id, updates);
-
-      // Refresh
-      await data.refreshProjects(effectiveTeacherId);
-      setDeleteSubmissionState({ open: false, project: null, stepNumber: null, deleting: false });
-      showAlert(`Step ${stepNumber} submission deleted and reset to Not Started.`, 'Deleted');
-    } catch (err: any) {
-      console.error('Delete submission failed:', err);
-      showAlert(err.message || 'Failed to delete submission.', 'Error');
-      setDeleteSubmissionState((s) => ({ ...s, deleting: false }));
-    }
-  };
-
-  return (
-    <Box sx={{ minHeight: '100vh', bgcolor: 'background.default' }}>
-      <ImpersonationBanner />
-      <AppBar position="static" color="default" elevation={1}>
-        <Toolbar sx={{ justifyContent: 'space-between' }}>
-          <Box
-            sx={{ display: 'flex', alignItems: 'center', gap: 2, cursor: 'pointer' }}
-            onClick={() => navigate('/')}
-          >
-            <img src={orbiliusLogo} alt="Orbilius" style={{ height: '40px' }} />
-            <Typography variant="h6" component="div" sx={{ fontWeight: 500 }}>
-              Orbilius
-            </Typography>
-          </Box>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-            {userProfile && (
-              <Typography variant="body1" sx={{ fontWeight: 500 }}>
-                {userProfile.first_name} {userProfile.last_name}
-              </Typography>
-            )}
-            <Chip label="Teacher" color="secondary" sx={{ fontWeight: 600 }} />
-            <Button
-              variant="outlined"
-              startIcon={<LogoutIcon />}
-              onClick={handleLogout}
-              sx={{ textTransform: 'none' }}
-            >
-              Logout
-            </Button>
-          </Box>
-        </Toolbar>
-      </AppBar>
-
-      <Container maxWidth="xl" sx={{ py: 4 }}>
-        <Stack spacing={4}>
-          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-            <Typography variant="h4" component="h1">
-              Teacher Dashboard
-            </Typography>
-            {projectsNeedingReview > 0 && (
-              <Tooltip
-                title={`${projectsNeedingReview} project${projectsNeedingReview === 1 ? '' : 's'} need${projectsNeedingReview === 1 ? 's' : ''} review`}
-                arrow
-              >
-                <Badge
-                  badgeContent={projectsNeedingReview}
-                  color="error"
-                  sx={{
-                    '& .MuiBadge-badge': { fontSize: '0.7rem', fontWeight: 700 },
-                    animation: 'bellRing 2s ease-in-out infinite',
-                    '@keyframes bellRing': {
-                      '0%': { transform: 'rotate(0deg)' },
-                      '5%': { transform: 'rotate(15deg)' },
-                      '10%': { transform: 'rotate(-13deg)' },
-                      '15%': { transform: 'rotate(11deg)' },
-                      '20%': { transform: 'rotate(-9deg)' },
-                      '25%': { transform: 'rotate(7deg)' },
-                      '30%': { transform: 'rotate(-5deg)' },
-                      '35%': { transform: 'rotate(3deg)' },
-                      '40%': { transform: 'rotate(0deg)' },
-                      '100%': { transform: 'rotate(0deg)' },
-                    },
-                  }}
-                >
-                  <NotificationsIcon sx={{ color: '#ffd700', fontSize: 28 }} />
-                </Badge>
-              </Tooltip>
-            )}
-          </Box>
-
-          {/* Students Section with Projects */}
-          {students.length === 0 ? (
-            <Paper sx={{ p: 4, textAlign: 'center' }}>
-              <Typography variant="h5" gutterBottom>
-                Welcome to Orbilius!
-              </Typography>
-              <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
-                You don't have any students yet. Invite students to join your class and start their
-                science fair journey.
-              </Typography>
-              <Button
-                variant="contained"
-                color="primary"
-                startIcon={<EmailIcon />}
-                onClick={() => setShowInviteModal(true)}
-                size="large"
-              >
-                Invite Your First Student
-              </Button>
-            </Paper>
-          ) : (
-            <Paper sx={{ p: 3 }}>
-              <Box
-                sx={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  mb: 2,
-                }}
-              >
-                <Typography variant="h5">Students & Projects</Typography>
-                <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Tooltip title={allStudentsExpanded ? 'Collapse All' : 'Expand All'}>
-                    <IconButton
-                      onClick={() => setAllStudentsExpanded(!allStudentsExpanded)}
-                      size="small"
-                      sx={{
-                        width: 40,
-                        height: 40,
-                        borderRadius: '50%',
-                      }}
+    return (
+        <Box sx={{ minHeight: '100vh', bgcolor: 'background.default' }}>
+            <ImpersonationBanner />
+            <AppBar position="static" color="default" elevation={1}>
+                <Toolbar sx={{ justifyContent: 'space-between' }}>
+                    <Box
+                        sx={{ display: 'flex', alignItems: 'center', gap: 2, cursor: 'pointer' }}
+                        onClick={() => navigate('/')}
                     >
-                      {allStudentsExpanded ? <UnfoldLessIcon /> : <UnfoldMoreIcon />}
-                    </IconButton>
-                  </Tooltip>
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    startIcon={<EmailIcon />}
-                    onClick={() => setShowInviteModal(true)}
-                  >
-                    Invite Student
-                  </Button>
-                </Box>
-              </Box>
-              <StudentsList
-                students={studentsHook.students}
-                projects={projects}
-                onDelete={studentsHook.openConfirm}
-                onResendInvitation={handleResendInvitation}
-                onEmailStudent={handleEmailStudent}
-                onEmailProjectStudent={handleEmailProjectStudent}
-                onStepClick={handleStepClick}
-                onViewSubmission={(project, stepNumber) => handleStepClick(project, stepNumber - 1)}
-                onDeleteSubmission={handleOpenDeleteSubmission}
-                getCurrentStepName={getCurrentStepName}
-                getCurrentStepSubmissionStatus={getCurrentStepSubmissionStatus}
-                navigate={navigate}
-                allExpanded={allStudentsExpanded}
-              />
-            </Paper>
-          )}
+                        <img src={orbiliusLogo} alt="Orbilius" style={{ height: '40px' }} />
+                        <Typography variant="h6" component="div" sx={{ fontWeight: 500 }}>
+                            Orbilius
+                        </Typography>
+                    </Box>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                        {userProfile && (
+                            <Typography variant="body1" sx={{ fontWeight: 500 }}>
+                                {userProfile.first_name} {userProfile.last_name}
+                            </Typography>
+                        )}
+                        <Chip label="Teacher" color="secondary" sx={{ fontWeight: 600 }} />
+                        <Button
+                            variant="outlined"
+                            startIcon={<LogoutIcon />}
+                            onClick={handleLogout}
+                            sx={{ textTransform: 'none' }}
+                        >
+                            Logout
+                        </Button>
+                    </Box>
+                </Toolbar>
+            </AppBar>
 
-          {/* Invitation Modal */}
-          {showInviteModal && (
-            <InviteModal
-              open={showInviteModal}
-              onClose={handleCloseInviteModal}
-              role="student"
-              teacherId={effectiveTeacherId}
-              showAlert={showAlert}
-              initialEmail={initialEmail}
+            <Container maxWidth="xl" sx={{ py: 4 }}>
+                <Stack spacing={4}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                        <Typography variant="h4" component="h1">
+                            Teacher Dashboard
+                        </Typography>
+                        {projectsNeedingReview > 0 && (
+                            <Tooltip
+                                title={`${projectsNeedingReview} project${projectsNeedingReview === 1 ? '' : 's'} need${projectsNeedingReview === 1 ? 's' : ''} review`}
+                                arrow
+                            >
+                                <Badge
+                                    badgeContent={projectsNeedingReview}
+                                    color="error"
+                                    sx={{
+                                        '& .MuiBadge-badge': { fontSize: '0.7rem', fontWeight: 700 },
+                                        animation: 'bellRing 2s ease-in-out infinite',
+                                        '@keyframes bellRing': {
+                                            '0%': { transform: 'rotate(0deg)' },
+                                            '5%': { transform: 'rotate(15deg)' },
+                                            '10%': { transform: 'rotate(-13deg)' },
+                                            '15%': { transform: 'rotate(11deg)' },
+                                            '20%': { transform: 'rotate(-9deg)' },
+                                            '25%': { transform: 'rotate(7deg)' },
+                                            '30%': { transform: 'rotate(-5deg)' },
+                                            '35%': { transform: 'rotate(3deg)' },
+                                            '40%': { transform: 'rotate(0deg)' },
+                                            '100%': { transform: 'rotate(0deg)' },
+                                        },
+                                    }}
+                                >
+                                    <NotificationsIcon sx={{ color: '#ffd700', fontSize: 28 }} />
+                                </Badge>
+                            </Tooltip>
+                        )}
+                    </Box>
+
+                    {/* Students Section with Projects */}
+                    {students.length === 0 ? (
+                        <Paper sx={{ p: 4, textAlign: 'center' }}>
+                            <Typography variant="h5" gutterBottom>
+                                Welcome to Orbilius!
+                            </Typography>
+                            <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
+                                You don't have any students yet. Invite students to join your class and start their
+                                science fair journey.
+                            </Typography>
+                            <Button
+                                variant="contained"
+                                color="primary"
+                                startIcon={<EmailIcon />}
+                                onClick={() => setShowInviteModal(true)}
+                                size="large"
+                            >
+                                Invite Your First Student
+                            </Button>
+                        </Paper>
+                    ) : (
+                        <Paper sx={{ p: 3 }}>
+                            <Box
+                                sx={{
+                                    display: 'flex',
+                                    justifyContent: 'space-between',
+                                    alignItems: 'center',
+                                    mb: 2,
+                                }}
+                            >
+                                <Typography variant="h5">Students & Projects</Typography>
+                                <Box sx={{ display: 'flex', gap: 1 }}>
+                                    <Tooltip title={allStudentsExpanded ? 'Collapse All' : 'Expand All'}>
+                                        <IconButton
+                                            onClick={() => setAllStudentsExpanded(!allStudentsExpanded)}
+                                            size="small"
+                                            sx={{ width: 40, height: 40, borderRadius: '50%' }}
+                                        >
+                                            {allStudentsExpanded ? <UnfoldLessIcon /> : <UnfoldMoreIcon />}
+                                        </IconButton>
+                                    </Tooltip>
+                                    <Button
+                                        variant="contained"
+                                        color="primary"
+                                        startIcon={<EmailIcon />}
+                                        onClick={() => setShowInviteModal(true)}
+                                    >
+                                        Invite Student
+                                    </Button>
+                                </Box>
+                            </Box>
+                            <StudentsList
+                                students={students}
+                                projects={projects}
+                                onDelete={studentsHook.openConfirm}
+                                onResendInvitation={handleResendInvitation}
+                                onEmailStudent={handleEmailStudent}
+                                onEmailProjectStudent={handleEmailProjectStudent}
+                                onStepClick={handleStepClick}
+                                onViewSubmission={(project, stepNumber) => handleStepClick(project, stepNumber - 1)}
+                                onDeleteSubmission={handleOpenDeleteSubmission}
+                                getCurrentStepName={getCurrentStepName}
+                                getCurrentStepSubmissionStatus={getCurrentStepSubmissionStatus}
+                                navigate={navigate}
+                                allExpanded={allStudentsExpanded}
+                            />
+                        </Paper>
+                    )}
+
+                    {/* Invitation Modal */}
+                    {showInviteModal && (
+                        <InviteModal
+                            open={showInviteModal}
+                            onClose={handleCloseInviteModal}
+                            role="student"
+                            teacherId={effectiveTeacherId}
+                            showAlert={showAlert}
+                            initialEmail={initialEmail}
+                        />
+                    )}
+
+                    {/* Resend Confirmation Dialog */}
+                    <Dialog open={resendConfirmOpen} onClose={() => setResendConfirmOpen(false)}>
+                        <DialogTitle>Resend Invitation</DialogTitle>
+                        <DialogContent>
+                            <DialogContentText>
+                                Are you sure you want to resend the invitation to {emailToResend}?
+                            </DialogContentText>
+                        </DialogContent>
+                        <DialogActions>
+                            <Button onClick={() => setResendConfirmOpen(false)}>Cancel</Button>
+                            <Button onClick={handleConfirmResend} variant="contained" color="primary">
+                                Resend
+                            </Button>
+                        </DialogActions>
+                    </Dialog>
+
+                    {/* Delete Confirmation Dialog */}
+                    <ConfirmDialog
+                        open={studentsHook.confirmState.open}
+                        title={`Delete ${studentsHook.confirmState.type}`}
+                        message={
+                            studentsHook.confirmState.status === 'active'
+                                ? `⚠️ WARNING: You are about to permanently delete ${studentsHook.confirmState.name} and ALL associated data.\n\nThis action will delete:\n• Student account\n• All student projects\n• All project submissions and files\n• All comments and feedback\n\nThis action CANNOT be undone. Are you absolutely sure you want to proceed?`
+                                : `Are you sure you want to delete the invitation for ${studentsHook.confirmState.name}?`
+                        }
+                        onConfirm={studentsHook.confirmDelete}
+                        onCancel={studentsHook.closeConfirm}
+                        confirmText="Delete"
+                        cancelText="Cancel"
+                        requireTypedConfirmation={
+                            studentsHook.confirmState.status === 'active' ? 'delete' : undefined
+                        }
+                    />
+
+                    {/* Delete Submission Confirmation Dialog */}
+                    <ConfirmDialog
+                        open={deleteSubmissionState.open}
+                        title="Delete Submission"
+                        message={`This will permanently delete the Step ${deleteSubmissionState.stepNumber} submission for "${deleteSubmissionState.project?.project_title}" and reset the step to Not Started. The student will need to re-submit.\n\nThis action cannot be undone.`}
+                        onConfirm={handleDeleteSubmission}
+                        onCancel={() =>
+                            setDeleteSubmissionState({
+                                open: false,
+                                project: null,
+                                stepNumber: null,
+                                deleting: false,
+                            })
+                        }
+                        confirmText={deleteSubmissionState.deleting ? 'Deleting...' : 'Delete'}
+                        cancelText="Cancel"
+                        requireTypedConfirmation="delete"
+                    />
+                </Stack>
+            </Container>
+
+            <AlertDialog
+                open={alertState.open}
+                title={alertState.title}
+                message={alertState.message}
+                onClose={closeAlert}
             />
-          )}
 
-          {/* Resend Confirmation Dialog */}
-          <Dialog open={resendConfirmOpen} onClose={() => setResendConfirmOpen(false)}>
-            <DialogTitle>Resend Invitation</DialogTitle>
-            <DialogContent>
-              <DialogContentText>
-                Are you sure you want to resend the invitation to {emailToResend}?
-              </DialogContentText>
-            </DialogContent>
-            <DialogActions>
-              <Button onClick={() => setResendConfirmOpen(false)}>Cancel</Button>
-              <Button onClick={handleConfirmResend} variant="contained" color="primary">
-                Resend
-              </Button>
-            </DialogActions>
-          </Dialog>
-
-          {/* Delete Confirmation Dialog */}
-          <ConfirmDialog
-            open={studentsHook.confirmState.open}
-            title={`Delete ${studentsHook.confirmState.type}`}
-            message={
-              studentsHook.confirmState.status === 'active'
-                ? `⚠️ WARNING: You are about to permanently delete ${studentsHook.confirmState.name} and ALL associated data.\n\nThis action will delete:\n• Student account\n• All student projects\n• All project submissions and files\n• All comments and feedback\n\nThis action CANNOT be undone. Are you absolutely sure you want to proceed?`
-                : `Are you sure you want to delete the invitation for ${studentsHook.confirmState.name}?`
-            }
-            onConfirm={studentsHook.confirmDelete}
-            onCancel={studentsHook.closeConfirm}
-            confirmText="Delete"
-            cancelText="Cancel"
-            requireTypedConfirmation={
-              studentsHook.confirmState.status === 'active' ? 'delete' : undefined
-            }
-          />
-
-          {/* Delete Submission Confirmation Dialog */}
-          <ConfirmDialog
-            open={deleteSubmissionState.open}
-            title="Delete Submission"
-            message={`This will permanently delete the Step ${deleteSubmissionState.stepNumber} submission for "${deleteSubmissionState.project?.project_title}" and reset the step to Not Started. The student will need to re-submit.\n\nThis action cannot be undone.`}
-            onConfirm={handleDeleteSubmission}
-            onCancel={() =>
-              setDeleteSubmissionState({
-                open: false,
-                project: null,
-                stepNumber: null,
-                deleting: false,
-              })
-            }
-            confirmText={deleteSubmissionState.deleting ? 'Deleting...' : 'Delete'}
-            cancelText="Cancel"
-            requireTypedConfirmation="delete"
-          />
-        </Stack>
-      </Container>
-      <AlertDialog
-        open={alertState.open}
-        title={alertState.title}
-        message={alertState.message}
-        onClose={closeAlert}
-      />
-      {submissionModal.open && submissionModal.projectId && submissionModal.stepNumber && (
-        <StepSubmissionModal
-          open={submissionModal.open}
-          onClose={handleCloseSubmissionModal}
-          projectId={submissionModal.projectId}
-          stepNumber={submissionModal.stepNumber}
-          project={submissionModal.project}
-        />
-      )}
-    </Box>
-  );
+            {submissionModal.open && submissionModal.projectId && submissionModal.stepNumber && (
+                <StepSubmissionModal
+                    open={submissionModal.open}
+                    onClose={handleCloseSubmissionModal}
+                    projectId={submissionModal.projectId}
+                    stepNumber={submissionModal.stepNumber}
+                    project={submissionModal.project}
+                />
+            )}
+        </Box>
+    )
 }

--- a/src/teacher/components/Dashboard/hooks/useData.ts
+++ b/src/teacher/components/Dashboard/hooks/useData.ts
@@ -1,92 +1,145 @@
-import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { auth } from '../../../../firebaseConfig';
-import { getDocument, getDocuments, buildConstraints } from '../../../../utils/firebaseHelpers';
-import { useAlert } from '../../../../hooks/useAlert';
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { auth } from '../../../../firebaseConfig'
+import { getDocument, getDocuments, buildConstraints } from '../../../../utils/firebaseHelpers'
+import { useAlert } from '../../../../hooks/useAlert'
+import { useStudents } from './useStudents'
+import type { Project, UserProfile } from '../../../../types'
+
+interface SubmissionModalState {
+    open: boolean
+    projectId: string | null
+    stepNumber: number | null
+    project: Project | null
+}
+
+interface DeleteSubmissionState {
+    open: boolean
+    project: Project | null
+    stepNumber: number | null
+    deleting: boolean
+}
 
 export function useDashboardData() {
-  const [user, setUser] = useState(null);
-  const [userProfile, setUserProfile] = useState(null);
-  const [projects, setProjects] = useState([]);
-  const navigate = useNavigate();
-  const { alertState, showAlert, closeAlert } = useAlert();
+    const [user, setUser] = useState<any>(null)
+    const [userProfile, setUserProfile] = useState<UserProfile | null>(null)
+    const [projects, setProjects] = useState<Project[]>([])
+    const navigate = useNavigate()
+    const { alertState, showAlert, closeAlert } = useAlert()
 
-  const fetchProjects = async (teacherId: string) => {
-    // Fetch all projects assigned to this teacher with student email
-    const { data: projectsData, error: projectsError } = await getDocuments(
-      'projects',
-      buildConstraints({
-        eq: { teacher_id: teacherId },
-        orderBy: { field: 'created_at', direction: 'desc' },
-      })
-    );
+    // Modal / UI state
+    const [showInviteModal, setShowInviteModal] = useState(false)
+    const [initialEmail, setInitialEmail] = useState('')
+    const [resendConfirmOpen, setResendConfirmOpen] = useState(false)
+    const [emailToResend, setEmailToResend] = useState('')
+    const [submissionModal, setSubmissionModal] = useState<SubmissionModalState>({
+        open: false,
+        projectId: null,
+        stepNumber: null,
+        project: null,
+    })
+    const [allStudentsExpanded, setAllStudentsExpanded] = useState(true)
+    const [deleteSubmissionState, setDeleteSubmissionState] = useState<DeleteSubmissionState>({
+        open: false,
+        project: null,
+        stepNumber: null,
+        deleting: false,
+    })
 
-    if (projectsError) {
-      console.error('Error fetching projects:', projectsError.message);
-      setProjects([]);
-    } else {
-      // Fetch student details for each project
-      const projectsWithStudents = await Promise.all(
-        ((projectsData as any[]) || []).map(async (project) => {
-          const { data: studentData } = await getDocument('users', project.student_id);
+    const impersonatingTeacherId = sessionStorage.getItem('impersonating_teacher_uid')
+    const effectiveTeacherId = impersonatingTeacherId || user?.uid
 
-          return {
-            ...project,
-            project_id: project.id, // Map Firestore document ID to project_id
-            student: studentData,
-          };
-        })
-      );
+    const fetchProjects = async (teacherId: string) => {
+        const { data: projectsData, error: projectsError } = await getDocuments(
+            'projects',
+            buildConstraints({
+                eq: { teacher_id: teacherId },
+                orderBy: { field: 'created_at', direction: 'desc' },
+            })
+        )
 
-      setProjects(projectsWithStudents);
+        if (projectsError) {
+            console.error('Error fetching projects:', projectsError.message)
+            setProjects([])
+        } else {
+            const projectsWithStudents = await Promise.all(
+                ((projectsData as any[]) || []).map(async project => {
+                    const { data: studentData } = await getDocument('users', project.student_id)
+                    return {
+                        ...project,
+                        project_id: project.id,
+                        student: studentData,
+                    }
+                })
+            )
+            setProjects(projectsWithStudents as Project[])
+        }
     }
-  };
 
-  useEffect(() => {
-    const fetchUserAndProjects = async () => {
-      const currentUser = auth.currentUser;
+    const studentsHook = useStudents(effectiveTeacherId, showAlert, fetchProjects)
 
-      if (!currentUser) {
-        navigate('/login');
-        return;
-      }
+    const projectsNeedingReview = projects.filter(project => {
+        for (let i = 1; i <= 5; i++) {
+            if (project[`step${i}_status` as keyof Project] === 'Submitted') return true
+        }
+        return false
+    }).length
 
-      setUser(currentUser as any);
+    useEffect(() => {
+        const fetchUserAndProjects = async () => {
+            const currentUser = auth.currentUser
 
-      // Check if admin is impersonating a teacher
-      const impersonatingTeacherId = sessionStorage.getItem('impersonating_teacher_uid');
-      const effectiveUserId = impersonatingTeacherId || currentUser.uid;
+            if (!currentUser) {
+                navigate('/login')
+                return
+            }
 
-      console.log('Impersonating teacher ID:', impersonatingTeacherId);
-      console.log('Effective user ID for data fetch:', effectiveUserId);
+            setUser(currentUser)
 
-      // Fetch user profile (use impersonated teacher's profile if applicable)
-      const { data: profile, error: profileError } = await getDocument('users', effectiveUserId);
+            const impersonatingId = sessionStorage.getItem('impersonating_teacher_uid')
+            const effectiveUserId = impersonatingId || currentUser.uid
 
-      console.log('Teacher Dashboard - Fetching profile for user ID:', effectiveUserId);
-      console.log('Teacher Dashboard - Profile data:', profile);
-      console.log('Teacher Dashboard - Profile error:', profileError);
+            const { data: profile, error: profileError } = await getDocument('users', effectiveUserId)
 
-      if (profileError) {
-        console.error('Error fetching user profile:', profileError.message);
-      } else {
-        setUserProfile(profile);
-      }
+            if (profileError) {
+                console.error('Error fetching user profile:', profileError.message)
+            } else {
+                setUserProfile(profile as UserProfile)
+            }
 
-      await fetchProjects(effectiveUserId);
-    };
+            await fetchProjects(effectiveUserId)
+        }
 
-    fetchUserAndProjects();
-  }, [navigate]);
+        fetchUserAndProjects()
+    }, [navigate])
 
-  return {
-    user,
-    userProfile,
-    projects,
-    navigate,
-    alertState,
-    showAlert,
-    closeAlert,
-    refreshProjects: fetchProjects,
-  };
+    return {
+        user,
+        userProfile,
+        projects,
+        navigate,
+        alertState,
+        showAlert,
+        closeAlert,
+        refreshProjects: fetchProjects,
+        showInviteModal,
+        setShowInviteModal,
+        initialEmail,
+        setInitialEmail,
+        resendConfirmOpen,
+        setResendConfirmOpen,
+        emailToResend,
+        setEmailToResend,
+        submissionModal,
+        setSubmissionModal,
+        allStudentsExpanded,
+        setAllStudentsExpanded,
+        deleteSubmissionState,
+        setDeleteSubmissionState,
+        impersonatingTeacherId,
+        effectiveTeacherId,
+        studentsHook,
+        students: studentsHook.students,
+        projectsNeedingReview,
+    }
 }

--- a/src/teacher/components/Dashboard/hooks/useHandlers.ts
+++ b/src/teacher/components/Dashboard/hooks/useHandlers.ts
@@ -1,124 +1,277 @@
-export function useDashboardHandlers(data: any) {
-  const { _navigate, userProfile, showAlert } = data;
+import { useCallback } from 'react'
+import { ref as storageRef, deleteObject } from 'firebase/storage'
+import { auth, storage } from '../../../../firebaseConfig'
+import { getDocuments, buildConstraints, deleteDocument, updateDocument } from '../../../../utils/firebaseHelpers'
+import type { Project, UserProfile } from '../../../../types'
+import type { NavigateFunction } from 'react-router-dom'
 
-  const getCurrentStepName = (stepNum) => {
-    const stepNames = {
-      1: 'Initial Research',
-      2: 'Design Brief',
-      3: 'Planning',
-      4: 'Implementation',
-      5: 'Archival Records',
-    };
-    return stepNames[stepNum] || 'Unknown';
-  };
+interface SubmissionModalState {
+    open: boolean
+    projectId: string | null
+    stepNumber: number | null
+    project: Project | null
+}
 
-  const getCurrentStepDueDate = (project) => {
-    const stepField = `step${project.current_step}_due_date`;
-    const dueDate = project[stepField];
+interface DeleteSubmissionState {
+    open: boolean
+    project: Project | null
+    stepNumber: number | null
+    deleting: boolean
+}
 
-    if (!dueDate) return 'N/A';
+interface DashboardData {
+    user: any
+    userProfile: UserProfile | null
+    navigate: NavigateFunction
+    showAlert: (message: string, title: string) => void
+    refreshProjects: (teacherId: string) => Promise<void>
+    emailToResend: string
+    effectiveTeacherId: string | undefined
+    setShowInviteModal: (v: boolean) => void
+    setInitialEmail: (v: string) => void
+    setResendConfirmOpen: (v: boolean) => void
+    setEmailToResend: (v: string) => void
+    setSubmissionModal: (v: SubmissionModalState) => void
+    deleteSubmissionState: DeleteSubmissionState
+    setDeleteSubmissionState: (
+        v: DeleteSubmissionState | ((prev: DeleteSubmissionState) => DeleteSubmissionState)
+    ) => void
+    studentsHook: { loadStudents: () => Promise<void> }
+}
 
-    const date = new Date(dueDate);
-    const today = new Date();
-    const isOverdue = date < today;
+const STEP_NAMES: Record<number, string> = {
+    1: 'Initial Research',
+    2: 'Design Brief',
+    3: 'Planning',
+    4: 'Implementation',
+    5: 'Archival Records',
+}
 
-    const formattedDate = date.toLocaleDateString('en-US', {
-      month: 'numeric',
-      day: 'numeric',
-      year: '2-digit',
-    });
+export function useDashboardHandlers(data: DashboardData) {
+    const {
+        user,
+        userProfile,
+        navigate,
+        showAlert,
+        refreshProjects,
+        emailToResend,
+        effectiveTeacherId,
+        setShowInviteModal,
+        setInitialEmail,
+        setResendConfirmOpen,
+        setEmailToResend,
+        setSubmissionModal,
+        deleteSubmissionState,
+        setDeleteSubmissionState,
+        studentsHook,
+    } = data
 
-    if (isOverdue) {
-      return `Overdue - ${formattedDate}`;
-    } else {
-      return `Due: ${formattedDate}`;
+    const getCurrentStepName = useCallback((stepNum: number): string => {
+        return STEP_NAMES[stepNum] || 'Unknown'
+    }, [])
+
+    const getCurrentStepDueDate = useCallback((project: Project): string => {
+        const stepField = `step${project.current_step}_due_date` as keyof Project
+        const dueDate = project[stepField] as string | undefined
+
+        if (!dueDate) return 'N/A'
+
+        const date = new Date(dueDate)
+        const isOverdue = date < new Date()
+        const formattedDate = date.toLocaleDateString('en-US', {
+            month: 'numeric',
+            day: 'numeric',
+            year: '2-digit',
+        })
+
+        return isOverdue ? `Overdue - ${formattedDate}` : `Due: ${formattedDate}`
+    }, [])
+
+    const getCurrentStepSubmissionStatus = useCallback((project: Project): string => {
+        const stepField = `step${project.current_step}_status` as keyof Project
+        return (project[stepField] as string) || 'Not Started'
+    }, [])
+
+    const getActionButtonText = useCallback((project: Project): string => {
+        const allApproved = [1, 2, 3, 4, 5].every(
+            step => project[`step${step}_status` as keyof Project] === 'Approved'
+        )
+        return allApproved ? 'Submit to Orbilius' : 'Email Student'
+    }, [])
+
+    const handleActionClick = useCallback((project: Project) => {
+        const allApproved = [1, 2, 3, 4, 5].every(
+            step => project[`step${step}_status` as keyof Project] === 'Approved'
+        )
+
+        if (allApproved) {
+            showAlert('Submit to Orbilius functionality coming soon!', 'Info')
+            return
+        }
+
+        const studentEmail = project.student?.email || project.email
+        const studentFirstName = project.student?.first_name || project.first_name
+        const currentStepStatus = project[`step${project.current_step}_status` as keyof Project] as string
+        const currentStepName = STEP_NAMES[project.current_step] || 'Unknown'
+
+        if (!studentEmail) {
+            showAlert('Student email not found. Please check the project data.', 'Error')
+            return
+        }
+
+        let subject: string, body: string
+
+        if (currentStepStatus === 'Submitted') {
+            subject = `Feedback on ${project.project_title} - Step ${project.current_step}`
+            body = `Hello ${studentFirstName},\n\nI have reviewed your submission for Step ${project.current_step}: ${currentStepName} of your project "${project.project_title}".\n\nPlease log into the Orbilius platform to view my feedback and next steps.\n\nIf you have any questions, please don't hesitate to reach out.\n\nBest regards,\n${userProfile?.first_name || 'Your Teacher'}`
+        } else {
+            subject = `Follow-up on ${project.project_title} - Step ${project.current_step}`
+            body = `Hello ${studentFirstName},\n\nI wanted to follow up on your project "${project.project_title}".\n\nYou are currently on Step ${project.current_step}: ${currentStepName}.\nCurrent status: ${currentStepStatus}\n\nPlease log into the Orbilius platform to continue your work or view any feedback.\n\nIf you need any assistance, please let me know.\n\nBest regards,\n${userProfile?.first_name || 'Your Teacher'}`
+        }
+
+        window.open(`mailto:${studentEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`)
+    }, [showAlert, userProfile])
+
+    const handleEmailStudent = useCallback((studentEmail: string) => {
+        window.open(`mailto:${studentEmail}`)
+    }, [])
+
+    const handleEmailProjectStudent = useCallback((project: Project) => {
+        const studentEmail = project.student?.email || project.email
+        const currentStepName = STEP_NAMES[project.current_step] || 'Unknown'
+
+        if (!studentEmail) {
+            showAlert('Student email not found. Please check the project data.', 'Error')
+            return
+        }
+
+        const subject = `${project.project_title} - Step ${project.current_step}: ${currentStepName}`
+        window.open(`mailto:${studentEmail}?subject=${encodeURIComponent(subject)}`)
+    }, [showAlert])
+
+    const handleCopyTeacherId = useCallback(() => {
+        if (!user?.uid) return
+        navigator.clipboard.writeText(user.uid)
+        showAlert('Teacher ID copied to clipboard!', 'Success')
+    }, [user, showAlert])
+
+    const handleCopySignupLink = useCallback(() => {
+        if (!user?.uid) return
+        const signupLink = `${window.location.origin}/signup?teacherId=${user.uid}`
+        navigator.clipboard.writeText(signupLink)
+        showAlert('Signup link copied to clipboard!', 'Success')
+    }, [user, showAlert])
+
+    const handleResendInvitation = useCallback((email: string) => {
+        setEmailToResend(email)
+        setResendConfirmOpen(true)
+    }, [setEmailToResend, setResendConfirmOpen])
+
+    const handleConfirmResend = useCallback(() => {
+        setResendConfirmOpen(false)
+        setInitialEmail(emailToResend)
+        setShowInviteModal(true)
+    }, [setResendConfirmOpen, setInitialEmail, emailToResend, setShowInviteModal])
+
+    const handleCloseInviteModal = useCallback(() => {
+        setShowInviteModal(false)
+        setInitialEmail('')
+        studentsHook.loadStudents()
+    }, [setShowInviteModal, setInitialEmail, studentsHook])
+
+    const handleLogout = useCallback(async () => {
+        await auth.signOut()
+        navigate('/login')
+    }, [navigate])
+
+    const handleStepClick = useCallback((project: Project, stepIndex: number) => {
+        const stepNumber = stepIndex + 1
+        const stepStatus = project[`step${stepNumber}_status` as keyof Project] as string
+
+        if (stepStatus === 'Submitted' || stepStatus === 'Revision Requested') {
+            navigate(`/teacher/step-approval/${project.project_id}/${stepNumber}`)
+        } else if (stepStatus === 'Approved') {
+            setSubmissionModal({ open: true, projectId: project.project_id, stepNumber, project })
+        }
+    }, [navigate, setSubmissionModal])
+
+    const handleCloseSubmissionModal = useCallback(() => {
+        setSubmissionModal({ open: false, projectId: null, stepNumber: null, project: null })
+    }, [setSubmissionModal])
+
+    const handleOpenDeleteSubmission = useCallback((project: Project, stepNumber: number) => {
+        setDeleteSubmissionState({ open: true, project, stepNumber, deleting: false })
+    }, [setDeleteSubmissionState])
+
+    const handleDeleteSubmission = useCallback(async () => {
+        const { project, stepNumber } = deleteSubmissionState
+        if (!project || !stepNumber) return
+
+        setDeleteSubmissionState(s => ({ ...s, deleting: true }))
+
+        try {
+            const { data: submissions } = await getDocuments(
+                'submissions',
+                buildConstraints({ eq: { project_id: project.project_id, step_number: stepNumber } })
+            )
+
+            if (submissions && (submissions as any[]).length > 0) {
+                const submission = (submissions as any[])[0]
+
+                if (submission.file_url) {
+                    try {
+                        const urlObj = new URL(submission.file_url)
+                        const pathMatch = urlObj.pathname.match(/\/o\/(.+?)(\?|$)/)
+                        if (pathMatch?.[1]) {
+                            await deleteObject(storageRef(storage, decodeURIComponent(pathMatch[1])))
+                        }
+                    } catch {
+                        // Non-critical — storage file deletion failure should not block the rest
+                    }
+                }
+
+                await deleteDocument('submissions', submission.id)
+            }
+
+            const updates: Record<string, string | number> = {
+                [`step${stepNumber}_status`]: 'Not Started',
+            }
+            if (stepNumber <= project.current_step) {
+                updates.current_step = stepNumber
+                updates.current_step_status = 'Not Started'
+            }
+            await updateDocument('projects', project.project_id, updates)
+
+            if (effectiveTeacherId) {
+                await refreshProjects(effectiveTeacherId)
+            }
+
+            setDeleteSubmissionState({ open: false, project: null, stepNumber: null, deleting: false })
+            showAlert(`Step ${stepNumber} submission deleted and reset to Not Started.`, 'Deleted')
+        } catch (err: any) {
+            console.error('Delete submission failed:', err)
+            showAlert(err.message || 'Failed to delete submission.', 'Error')
+            setDeleteSubmissionState(s => ({ ...s, deleting: false }))
+        }
+    }, [deleteSubmissionState, effectiveTeacherId, refreshProjects, setDeleteSubmissionState, showAlert])
+
+    return {
+        getCurrentStepName,
+        getCurrentStepDueDate,
+        getCurrentStepSubmissionStatus,
+        getActionButtonText,
+        handleActionClick,
+        handleEmailStudent,
+        handleEmailProjectStudent,
+        handleCopyTeacherId,
+        handleCopySignupLink,
+        handleResendInvitation,
+        handleConfirmResend,
+        handleCloseInviteModal,
+        handleLogout,
+        handleStepClick,
+        handleCloseSubmissionModal,
+        handleOpenDeleteSubmission,
+        handleDeleteSubmission,
     }
-  };
-
-  const getCurrentStepSubmissionStatus = (project) => {
-    const stepField = `step${project.current_step}_status`;
-    const status = project[stepField];
-
-    return status || 'Not Started';
-  };
-
-  const getActionButtonText = (project) => {
-    const allStepsApproved = [1, 2, 3, 4, 5].every(
-      (step) => project[`step${step}_status`] === 'Approved'
-    );
-
-    if (allStepsApproved) {
-      return 'Submit to Orbilius';
-    }
-
-    const currentStepStatus = project[`step${project.current_step}_status`];
-    if (currentStepStatus === 'Submitted') {
-      return 'Email Student';
-    }
-
-    return 'Email Student';
-  };
-
-  const handleActionClick = (project) => {
-    const allStepsApproved = [1, 2, 3, 4, 5].every(
-      (step) => project[`step${step}_status`] === 'Approved'
-    );
-
-    if (allStepsApproved) {
-      showAlert('Submit to Orbilius functionality coming soon!', 'Info');
-      return;
-    }
-
-    const studentEmail = project.student?.email || project.email;
-    const studentFirstName = project.student?.first_name || project.first_name;
-    const currentStepStatus = project[`step${project.current_step}_status`];
-    const currentStepName = getCurrentStepName(project.current_step);
-
-    if (!studentEmail) {
-      showAlert('Student email not found. Please check the project data.', 'Error');
-      return;
-    }
-
-    let subject, body;
-
-    if (currentStepStatus === 'Submitted') {
-      subject = `Feedback on ${project.project_title} - Step ${project.current_step}`;
-      body = `Hello ${studentFirstName},
-
-I have reviewed your submission for Step ${project.current_step}: ${currentStepName} of your project "${project.project_title}".
-
-Please log into the Orbilius platform to view my feedback and next steps.
-
-If you have any questions, please don't hesitate to reach out.
-
-Best regards,
-${userProfile?.first_name || 'Your Teacher'}`;
-    } else {
-      subject = `Follow-up on ${project.project_title} - Step ${project.current_step}`;
-      body = `Hello ${studentFirstName},
-
-I wanted to follow up on your project "${project.project_title}".
-
-You are currently on Step ${project.current_step}: ${currentStepName}.
-Current status: ${currentStepStatus}
-
-Please log into the Orbilius platform to continue your work or view any feedback.
-
-If you need any assistance, please let me know.
-
-Best regards,
-${userProfile?.first_name || 'Your Teacher'}`;
-    }
-
-    const mailtoLink = `mailto:${studentEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
-    window.open(mailtoLink);
-  };
-
-  return {
-    getCurrentStepName,
-    getCurrentStepDueDate,
-    getCurrentStepSubmissionStatus,
-    getActionButtonText,
-    handleActionClick,
-  };
 }

--- a/src/teacher/components/Dashboard/hooks/useStudents.ts
+++ b/src/teacher/components/Dashboard/hooks/useStudents.ts
@@ -53,8 +53,6 @@ export function useStudents(
 
     setLoading(true);
 
-    console.log('useStudents: Loading students for teacher:', teacherId);
-
     // Fetch active students
     const { data: activeStudentsData, error } = await getDocuments(
       'users',
@@ -70,8 +68,6 @@ export function useStudents(
       console.error('Error fetching students:', error);
       showAlert('Failed to load students: ' + error.message, 'Error');
     } else {
-      console.log('useStudents: Found active students:', activeStudentsData?.length || 0);
-
       // Map students and fetch their grades from projects
       activeStudents = await Promise.all(
         (activeStudentsData || []).map(async (student) => {
@@ -105,7 +101,6 @@ export function useStudents(
     }
 
     // Fetch pending invitations for students
-    console.log('useStudents: Fetching pending invitations for teacher:', teacherId);
     try {
       // First, try to fetch with all constraints
       let pendingInvites = null;
@@ -141,8 +136,6 @@ export function useStudents(
         // Still show active students even if pending invitations fail
         setStudents(activeStudents);
       } else {
-        console.log('useStudents: Found pending invitations:', pendingInvites?.length || 0);
-
         // Get emails of active students to avoid duplicates
         const activeStudentEmails = new Set(activeStudents.map((s) => s.email));
 
@@ -199,8 +192,6 @@ export function useStudents(
         }
       } else {
         // Delete active student using Cloud Function
-        console.log('Deleting active student:', confirmState.id);
-
         const response = await fetch(CLOUD_FUNCTIONS.deleteStudent, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/src/teacher/components/StepApproval/StepApproval.tsx
+++ b/src/teacher/components/StepApproval/StepApproval.tsx
@@ -1,535 +1,461 @@
-import React, { useRef, useCallback, useState, useEffect } from 'react';
-import { Document, Page, pdfjs } from 'react-pdf';
+import React from 'react'
+import { Document, Page, pdfjs } from 'react-pdf'
 import {
-  Box,
-  Container,
-  Typography,
-  Button,
-  Paper,
-  Stack,
-  CircularProgress,
-  Link,
-  ButtonGroup,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  IconButton,
-} from '@mui/material';
+    Box,
+    Container,
+    Typography,
+    Button,
+    Paper,
+    Stack,
+    CircularProgress,
+    Link,
+    ButtonGroup,
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    IconButton,
+} from '@mui/material'
 import {
-  ZoomIn as ZoomInIcon,
-  ZoomOut as ZoomOutIcon,
-  ZoomOutMap as FitIcon,
-  ArrowBack as ArrowBackIcon,
-  Close as CloseIcon,
-  PlayArrow as PlayArrowIcon,
-  OpenInNew as OpenInNewIcon,
-} from '@mui/icons-material';
-import { useStepApprovalData } from './hooks/useData';
-import { useStepApprovalHandlers } from './hooks/useHandlers';
-import AlertDialog from '../../../components/AlertDialog/AlertDialog';
-import CommentThread from '../../../components/CommentThread/CommentThread';
-import type { CommentThreadHandle } from '../../../components/CommentThread/CommentThread';
-import SubmissionHistory from '../../../components/SubmissionHistory/SubmissionHistory';
+    ZoomIn as ZoomInIcon,
+    ZoomOut as ZoomOutIcon,
+    ZoomOutMap as FitIcon,
+    ArrowBack as ArrowBackIcon,
+    Close as CloseIcon,
+    PlayArrow as PlayArrowIcon,
+    OpenInNew as OpenInNewIcon,
+} from '@mui/icons-material'
+import { useStepApprovalData } from './hooks/useData'
+import { useStepApprovalHandlers } from './hooks/useHandlers'
+import AlertDialog from '../../../components/AlertDialog/AlertDialog'
+import CommentThread from '../../../components/CommentThread/CommentThread'
+import SubmissionHistory from '../../../components/SubmissionHistory/SubmissionHistory'
 
 // Use CDN that matches installed pdfjs-dist version
-pdfjs.GlobalWorkerOptions.workerSrc = `https://unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;
+pdfjs.GlobalWorkerOptions.workerSrc = `https://unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`
 
 // Memoized PDF viewer — prevents re-renders when parent state (e.g. comment) changes
 const PdfViewer = React.memo(function PdfViewer({
-  file,
-  scale,
-  pageNumber,
-  pdfVersion,
-  onLoadSuccess,
-  onLoadError,
-  onRenderSuccess,
+    file,
+    scale,
+    pageNumber,
+    pdfVersion,
+    onLoadSuccess,
+    onLoadError,
+    onRenderSuccess,
 }: {
-  file: string;
-  scale: number;
-  pageNumber: number;
-  pdfVersion: string;
-  onLoadSuccess: (pdf: any) => void;
-  onLoadError: (err: any) => void;
-  onRenderSuccess: (page: any) => void;
+    file: string
+    scale: number
+    pageNumber: number
+    pdfVersion: string
+    onLoadSuccess: (pdf: { numPages: number }) => void
+    onLoadError: (err: Error) => void
+    onRenderSuccess: (page: any) => void
 }) {
-  return (
-    <Document
-      file={file}
-      onLoadSuccess={onLoadSuccess}
-      onLoadError={onLoadError}
-      options={{
-        cMapUrl: `https://unpkg.com/pdfjs-dist@${pdfVersion}/cmaps/`,
-        cMapPacked: true,
-      }}
-    >
-      <Page
-        pageNumber={pageNumber}
-        renderTextLayer={false}
-        renderAnnotationLayer={false}
-        scale={scale}
-        onRenderSuccess={onRenderSuccess}
-      />
-    </Document>
-  );
-});
+    return (
+        <Document
+            file={file}
+            onLoadSuccess={onLoadSuccess}
+            onLoadError={onLoadError}
+            options={{
+                cMapUrl: `https://unpkg.com/pdfjs-dist@${pdfVersion}/cmaps/`,
+                cMapPacked: true,
+            }}
+        >
+            <Page
+                pageNumber={pageNumber}
+                renderTextLayer={false}
+                renderAnnotationLayer={false}
+                scale={scale}
+                onRenderSuccess={onRenderSuccess}
+            />
+        </Document>
+    )
+})
 
 export default function StepApproval() {
-  const [showYouTubePlayer, setShowYouTubePlayer] = React.useState<boolean>(false);
-  const [isPoppedOut, setIsPoppedOut] = useState(false);
-  const popupRef = useRef<Window | null>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const commentThreadRef = useRef<CommentThreadHandle>(null);
-  const pdfPageWidthRef = useRef<number>(612);
-  const pdfPageHeightRef = useRef<number>(792);
+    const data = useStepApprovalData()
+    const handlers = useStepApprovalHandlers(data)
 
-  // Poll the popup window to detect when it's closed
-  useEffect(() => {
-    if (!isPoppedOut) return;
-    const interval = setInterval(() => {
-      if (popupRef.current?.closed) {
-        setIsPoppedOut(false);
-        popupRef.current = null;
-      }
-    }, 500);
-    return () => clearInterval(interval);
-  }, [isPoppedOut]);
+    const {
+        loading,
+        project,
+        submissionFile,
+        submissionDownloadUrl,
+        youtubeLink,
+        numPages,
+        pageNumber,
+        setPageNumber,
+        scale,
+        setScale,
+        isApproving,
+        isSavingComment,
+        stepNumber,
+        projectId,
+        navigate,
+        alertState,
+        closeAlert,
+        showYouTubePlayer,
+        setShowYouTubePlayer,
+        isPoppedOut,
+        setIsPoppedOut,
+        navigateOnClose,
+        setNavigateOnClose,
+        popupRef,
+        containerRef,
+        commentThreadRef,
+    } = data
 
-  const data = useStepApprovalData();
-  const handlers = useStepApprovalHandlers(data);
+    const {
+        getStepName,
+        extractYouTubeVideoId,
+        onDocumentLoadSuccess,
+        onDocumentLoadError,
+        handleFitPage,
+        handlePageRenderSuccess,
+        handleSaveComment,
+        handleApprove,
+    } = handlers
 
-  const {
-    loading,
-    project,
-    submissionFile,
-    submissionDownloadUrl,
-    youtubeLink,
-    numPages,
-    pageNumber,
-    setPageNumber,
-    scale,
-    setScale,
-    isApproving,
-    isSavingComment,
-    stepNumber,
-    projectId,
-    navigate,
-    alertState,
-    closeAlert,
-  } = data;
-
-  const [navigateOnClose, setNavigateOnClose] = useState(false);
-
-  const { handleSaveComment, handleApprove, getStepName } = handlers;
-
-  const onDocumentLoadSuccess = useCallback(({ numPages: n }: { numPages: number }) => {
-    data.setNumPages(n);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const onDocumentLoadError = useCallback((error: any) => {
-    console.error('PDF load error:', error);
-  }, []);
-
-  const handleFitPage = useCallback(() => {
-    if (!containerRef.current) {
-      setScale(1);
-      return;
-    }
-    const containerWidth = containerRef.current.clientWidth - 32; // subtract p:2 padding
-    const containerHeight = containerRef.current.clientHeight - 32;
-    const widthScale = containerWidth / pdfPageWidthRef.current;
-    const heightScale = containerHeight / pdfPageHeightRef.current;
-    const fitScale = Math.min(widthScale, heightScale);
-    setScale(Math.round(fitScale * 100) / 100);
-  }, [setScale]);
-
-  const handlePageRenderSuccess = useCallback((page: any) => {
-    if (page?.originalWidth) pdfPageWidthRef.current = page.originalWidth;
-    if (page?.originalHeight) pdfPageHeightRef.current = page.originalHeight;
-  }, []);
-
-  const extractYouTubeVideoId = (url: string): string | null => {
-    if (!url) return null;
-
-    // Handle various YouTube URL formats
-    const patterns = [
-      /(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&\n?#]+)/,
-      /youtube\.com\/embed\/([^&\n?#]+)/,
-      /youtube\.com\/v\/([^&\n?#]+)/,
-    ];
-
-    for (const pattern of patterns) {
-      const match = url.match(pattern);
-      if (match && match[1]) {
-        return match[1];
-      }
-    }
-
-    return null;
-  };
-
-  if (loading) {
-    return (
-      <Box
-        sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh' }}
-      >
-        <CircularProgress />
-      </Box>
-    );
-  }
-
-  if (!project) {
-    return (
-      <Box
-        sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh' }}
-      >
-        <Typography color="error">Project not found</Typography>
-      </Box>
-    );
-  }
-
-  return (
-    <Box
-      sx={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        display: 'flex',
-        flexDirection: 'column',
-        bgcolor: 'background.default',
-      }}
-    >
-      <Container
-        maxWidth="xl"
-        sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0, py: 2 }}
-      >
-        <Stack spacing={1} sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
-          {/* Header */}
-          <Box sx={{ flexShrink: 0 }}>
-            <Typography variant="h5" sx={{ mb: 0.5 }}>
-              Review Step {stepNumber}: {getStepName(stepNumber)}
-            </Typography>
-            <Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap', fontSize: '0.875rem' }}>
-              <Typography variant="body2" color="text.primary">
-                <strong>Student:</strong> {project.student?.first_name} {project.student?.last_name}
-              </Typography>
-              <Typography variant="body2" color="text.primary">
-                <strong>Project:</strong> {project.project_title || 'Untitled Project'}
-              </Typography>
+    if (loading) {
+        return (
+            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh' }}>
+                <CircularProgress />
             </Box>
-          </Box>
+        )
+    }
 
-          <Stack
-            spacing={1}
-            sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}
-          >
-            {submissionFile && (
-              <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
-                <Stack
-                  spacing={1}
-                  sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}
-                >
-                  {/* Toolbar */}
-                  <Box
-                    sx={{
-                      flexShrink: 0,
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'space-between',
-                      gap: 2,
-                    }}
-                  >
-                    <Button
-                      variant="outlined"
-                      onClick={() => navigate('/teacher/dashboard')}
-                      startIcon={<ArrowBackIcon />}
-                      size="small"
-                    >
-                      Back to Dashboard
-                    </Button>
-                    <Box
-                      sx={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 2,
-                        flex: 1,
-                        justifyContent: 'center',
-                      }}
-                    >
-                      <Button
-                        onClick={() => setPageNumber(Math.max(1, pageNumber - 1))}
-                        disabled={pageNumber <= 1}
-                        variant="outlined"
-                        size="small"
-                      >
-                        Previous
-                      </Button>
-                      <Typography variant="body2">
-                        Page {pageNumber} of {numPages || '--'}
-                      </Typography>
-                      <Button
-                        onClick={() => setPageNumber(Math.min(numPages, pageNumber + 1))}
-                        disabled={pageNumber >= numPages}
-                        variant="outlined"
-                        size="small"
-                      >
-                        Next
-                      </Button>
-                      <Box sx={{ ml: 2 }} />
-                      <ButtonGroup size="small" variant="outlined">
-                        <Button
-                          onClick={() => setScale((prev) => Math.min(prev + 0.25, 3))}
-                          disabled={scale >= 3}
-                          startIcon={<ZoomInIcon />}
-                        >
-                          Zoom In
-                        </Button>
-                        <Button
-                          onClick={() => setScale((prev) => Math.max(prev - 0.25, 0.5))}
-                          disabled={scale <= 0.5}
-                          startIcon={<ZoomOutIcon />}
-                        >
-                          Zoom Out
-                        </Button>
-                        <Button onClick={handleFitPage} startIcon={<FitIcon />}>
-                          Fit
-                        </Button>
-                      </ButtonGroup>
-                      <Typography variant="body2" sx={{ ml: 1 }}>
-                        {Math.round(scale * 100)}%
-                      </Typography>
-                    </Box>
-                    <Box sx={{ display: 'flex', gap: 1 }}>
-                      <Button
-                        variant="outlined"
-                        size="small"
-                        startIcon={<OpenInNewIcon />}
-                        onClick={() => {
-                          const popup = window.open(
-                            submissionFile as string,
-                            '_blank',
-                            'width=900,height=700'
-                          );
-                          if (popup) {
-                            popupRef.current = popup;
-                            setIsPoppedOut(true);
-                          }
-                        }}
-                      >
-                        Pop Out
-                      </Button>
-                      {youtubeLink && (
-                        <Button
-                          variant="contained"
-                          color="primary"
-                          onClick={() => setShowYouTubePlayer(true)}
-                          startIcon={<PlayArrowIcon />}
-                          size="small"
-                        >
-                          Watch Video
-                        </Button>
-                      )}
-                    </Box>
-                  </Box>
+    if (!project) {
+        return (
+            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh' }}>
+                <Typography color="error">Project not found</Typography>
+            </Box>
+        )
+    }
 
-                  {/* PDF viewer */}
-                  {isPoppedOut ? (
-                    <Box
-                      sx={{
-                        flex: 1,
-                        minHeight: 0,
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        border: '1px solid',
-                        borderColor: '#1e4976',
-                        borderRadius: 1,
-                        bgcolor: '#0a1929',
-                        color: 'text.secondary',
-                      }}
-                    >
-                      <Typography variant="body2">PDF opened in separate window</Typography>
-                    </Box>
-                  ) : (
-                    <Box
-                      ref={containerRef}
-                      sx={{
-                        flex: 1,
-                        minHeight: 0,
-                        display: 'flex',
-                        justifyContent: 'center',
-                        overflow: 'auto',
-                        border: '1px solid',
-                        borderColor: '#1e4976',
-                        borderRadius: 1,
-                        bgcolor: '#0a1929',
-                        p: 2,
-                      }}
-                    >
-                      <PdfViewer
-                        file={submissionFile as string}
-                        scale={scale}
-                        pageNumber={pageNumber}
-                        pdfVersion={pdfjs.version}
-                        onLoadSuccess={onDocumentLoadSuccess}
-                        onLoadError={onDocumentLoadError}
-                        onRenderSuccess={handlePageRenderSuccess}
-                      />
-                    </Box>
-                  )}
-                </Stack>
-              </Box>
-            )}
-
-            {!submissionFile && submissionDownloadUrl && (
-              <Box sx={{ p: 2, textAlign: 'center' }}>
-                <Typography color="text.secondary" sx={{ mb: 1 }}>
-                  File preview unavailable.
-                </Typography>
-                <Button
-                  variant="outlined"
-                  component="a"
-                  href={submissionDownloadUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Download Submission
-                </Button>
-              </Box>
-            )}
-
-            {!submissionFile && !submissionDownloadUrl && !youtubeLink && (
-              <Box sx={{ p: 2, textAlign: 'center' }}>
-                <Typography color="text.secondary">No submission found for this step</Typography>
-              </Box>
-            )}
-
-            {/* Bottom panel - always visible */}
-            <Paper sx={{ flexShrink: 0, p: 2 }}>
-              <Stack spacing={2}>
-                <SubmissionHistory
-                  projectId={projectId!}
-                  stepNumber={parseInt(stepNumber!)}
-                />
-                <CommentThread
-                  ref={commentThreadRef}
-                  projectId={projectId!}
-                  stepNumber={parseInt(stepNumber!)}
-                  maxHeight="200px"
-                />
-
-                <Stack direction="row" spacing={2} justifyContent="flex-end">
-                  <Button
-                    variant="contained"
-                    color="warning"
-                    onClick={async () => {
-                      popupRef.current?.close();
-                      // Submit any text in the comment field first
-                      if (commentThreadRef.current?.getCommentText()) {
-                        await commentThreadRef.current.submitComment();
-                      }
-                      await handleSaveComment();
-                      setNavigateOnClose(true);
-                    }}
-                    disabled={isSavingComment}
-                  >
-                    {isSavingComment ? 'Saving...' : 'Return to Student for Revision'}
-                  </Button>
-                  <Button
-                    variant="contained"
-                    onClick={() => {
-                      popupRef.current?.close();
-                      handleApprove();
-                    }}
-                    disabled={isApproving}
-                    color="success"
-                  >
-                    {isApproving ? 'Approving...' : 'Approve Step'}
-                  </Button>
-                </Stack>
-              </Stack>
-            </Paper>
-          </Stack>
-        </Stack>
-      </Container>
-
-      {/* YouTube Video Modal */}
-      <Dialog
-        open={showYouTubePlayer}
-        onClose={() => setShowYouTubePlayer(false)}
-        maxWidth="lg"
-        fullWidth
-        PaperProps={{
-          sx: {
-            height: '80vh',
-            maxHeight: '80vh',
-          },
-        }}
-      >
-        <DialogTitle sx={{ pb: 1 }}>
-          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <Typography variant="h6">YouTube Video Submission</Typography>
-            <IconButton onClick={() => setShowYouTubePlayer(false)}>
-              <CloseIcon />
-            </IconButton>
-          </Box>
-        </DialogTitle>
-        <DialogContent>
-          <Box
+    return (
+        <Box
             sx={{
-              position: 'relative',
-              paddingBottom: '56.25%',
-              height: 0,
-              overflow: 'hidden',
-              width: '100%',
-              borderRadius: 1,
-              bgcolor: '#000',
+                position: 'fixed',
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                display: 'flex',
+                flexDirection: 'column',
+                bgcolor: 'background.default',
             }}
-          >
-            {youtubeLink && extractYouTubeVideoId(youtubeLink) ? (
-              <iframe
-                style={{
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
-                  width: '100%',
-                  height: '100%',
-                }}
-                src={`https://www.youtube.com/embed/${extractYouTubeVideoId(youtubeLink)}`}
-                title="YouTube video player"
-                frameBorder="0"
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                allowFullScreen
-              />
-            ) : (
-              <Box sx={{ p: 2 }}>
-                <Typography color="error">Invalid YouTube URL</Typography>
-              </Box>
-            )}
-          </Box>
-        </DialogContent>
-        <DialogActions sx={{ p: 2 }}>
-          <Button onClick={() => setShowYouTubePlayer(false)} variant="contained">
-            Close
-          </Button>
-        </DialogActions>
-      </Dialog>
+        >
+            <Container
+                maxWidth="xl"
+                sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0, py: 2 }}
+            >
+                <Stack spacing={1} sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+                    {/* Header */}
+                    <Box sx={{ flexShrink: 0 }}>
+                        <Typography variant="h5" sx={{ mb: 0.5 }}>
+                            Review Step {stepNumber}: {getStepName(Number(stepNumber))}
+                        </Typography>
+                        <Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap', fontSize: '0.875rem' }}>
+                            <Typography variant="body2" color="text.primary">
+                                <strong>Student:</strong> {project.student?.first_name} {project.student?.last_name}
+                            </Typography>
+                            <Typography variant="body2" color="text.primary">
+                                <strong>Project:</strong> {project.project_title || 'Untitled Project'}
+                            </Typography>
+                        </Box>
+                    </Box>
 
-      <AlertDialog
-        open={alertState.open}
-        title={alertState.title}
-        message={alertState.message}
-        onClose={() => {
-          closeAlert();
-          if (navigateOnClose) {
-            setNavigateOnClose(false);
-            navigate('/teacher/dashboard');
-          }
-        }}
-      />
-    </Box>
-  );
+                    <Stack spacing={1} sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+                        {submissionFile && (
+                            <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+                                <Stack spacing={1} sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+                                    {/* Toolbar */}
+                                    <Box
+                                        sx={{
+                                            flexShrink: 0,
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                            justifyContent: 'space-between',
+                                            gap: 2,
+                                        }}
+                                    >
+                                        <Button
+                                            variant="outlined"
+                                            onClick={() => navigate('/teacher/dashboard')}
+                                            startIcon={<ArrowBackIcon />}
+                                            size="small"
+                                        >
+                                            Back to Dashboard
+                                        </Button>
+                                        <Box
+                                            sx={{
+                                                display: 'flex',
+                                                alignItems: 'center',
+                                                gap: 2,
+                                                flex: 1,
+                                                justifyContent: 'center',
+                                            }}
+                                        >
+                                            <Button
+                                                onClick={() => setPageNumber(Math.max(1, pageNumber - 1))}
+                                                disabled={pageNumber <= 1}
+                                                variant="outlined"
+                                                size="small"
+                                            >
+                                                Previous
+                                            </Button>
+                                            <Typography variant="body2">
+                                                Page {pageNumber} of {numPages || '--'}
+                                            </Typography>
+                                            <Button
+                                                onClick={() => setPageNumber(Math.min(numPages!, pageNumber + 1))}
+                                                disabled={pageNumber >= (numPages ?? 0)}
+                                                variant="outlined"
+                                                size="small"
+                                            >
+                                                Next
+                                            </Button>
+                                            <Box sx={{ ml: 2 }} />
+                                            <ButtonGroup size="small" variant="outlined">
+                                                <Button
+                                                    onClick={() => setScale(prev => Math.min(prev + 0.25, 3))}
+                                                    disabled={scale >= 3}
+                                                    startIcon={<ZoomInIcon />}
+                                                >
+                                                    Zoom In
+                                                </Button>
+                                                <Button
+                                                    onClick={() => setScale(prev => Math.max(prev - 0.25, 0.5))}
+                                                    disabled={scale <= 0.5}
+                                                    startIcon={<ZoomOutIcon />}
+                                                >
+                                                    Zoom Out
+                                                </Button>
+                                                <Button onClick={handleFitPage} startIcon={<FitIcon />}>
+                                                    Fit
+                                                </Button>
+                                            </ButtonGroup>
+                                            <Typography variant="body2" sx={{ ml: 1 }}>
+                                                {Math.round(scale * 100)}%
+                                            </Typography>
+                                        </Box>
+                                        <Box sx={{ display: 'flex', gap: 1 }}>
+                                            <Button
+                                                variant="outlined"
+                                                size="small"
+                                                startIcon={<OpenInNewIcon />}
+                                                onClick={() => {
+                                                    const popup = window.open(
+                                                        submissionFile as string,
+                                                        '_blank',
+                                                        'width=900,height=700'
+                                                    )
+                                                    if (popup) {
+                                                        popupRef.current = popup
+                                                        setIsPoppedOut(true)
+                                                    }
+                                                }}
+                                            >
+                                                Pop Out
+                                            </Button>
+                                            {youtubeLink && (
+                                                <Button
+                                                    variant="contained"
+                                                    color="primary"
+                                                    onClick={() => setShowYouTubePlayer(true)}
+                                                    startIcon={<PlayArrowIcon />}
+                                                    size="small"
+                                                >
+                                                    Watch Video
+                                                </Button>
+                                            )}
+                                        </Box>
+                                    </Box>
+
+                                    {/* PDF viewer */}
+                                    {isPoppedOut ? (
+                                        <Box
+                                            sx={{
+                                                flex: 1,
+                                                minHeight: 0,
+                                                display: 'flex',
+                                                alignItems: 'center',
+                                                justifyContent: 'center',
+                                                border: '1px solid',
+                                                borderColor: '#1e4976',
+                                                borderRadius: 1,
+                                                bgcolor: '#0a1929',
+                                                color: 'text.secondary',
+                                            }}
+                                        >
+                                            <Typography variant="body2">PDF opened in separate window</Typography>
+                                        </Box>
+                                    ) : (
+                                        <Box
+                                            ref={containerRef}
+                                            sx={{
+                                                flex: 1,
+                                                minHeight: 0,
+                                                display: 'flex',
+                                                justifyContent: 'center',
+                                                overflow: 'auto',
+                                                border: '1px solid',
+                                                borderColor: '#1e4976',
+                                                borderRadius: 1,
+                                                bgcolor: '#0a1929',
+                                                p: 2,
+                                            }}
+                                        >
+                                            <PdfViewer
+                                                file={submissionFile as string}
+                                                scale={scale}
+                                                pageNumber={pageNumber}
+                                                pdfVersion={pdfjs.version}
+                                                onLoadSuccess={onDocumentLoadSuccess}
+                                                onLoadError={onDocumentLoadError}
+                                                onRenderSuccess={handlePageRenderSuccess}
+                                            />
+                                        </Box>
+                                    )}
+                                </Stack>
+                            </Box>
+                        )}
+
+                        {!submissionFile && submissionDownloadUrl && (
+                            <Box sx={{ p: 2, textAlign: 'center' }}>
+                                <Typography color="text.secondary" sx={{ mb: 1 }}>
+                                    File preview unavailable.
+                                </Typography>
+                                <Button
+                                    variant="outlined"
+                                    component="a"
+                                    href={submissionDownloadUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    Download Submission
+                                </Button>
+                            </Box>
+                        )}
+
+                        {!submissionFile && !submissionDownloadUrl && !youtubeLink && (
+                            <Box sx={{ p: 2, textAlign: 'center' }}>
+                                <Typography color="text.secondary">No submission found for this step</Typography>
+                            </Box>
+                        )}
+
+                        {/* Bottom panel — always visible */}
+                        <Paper sx={{ flexShrink: 0, p: 2 }}>
+                            <Stack spacing={2}>
+                                <SubmissionHistory
+                                    projectId={projectId!}
+                                    stepNumber={parseInt(stepNumber!)}
+                                />
+                                <CommentThread
+                                    ref={commentThreadRef}
+                                    projectId={projectId!}
+                                    stepNumber={parseInt(stepNumber!)}
+                                    maxHeight="200px"
+                                />
+
+                                <Stack direction="row" spacing={2} justifyContent="flex-end">
+                                    <Button
+                                        variant="contained"
+                                        color="warning"
+                                        onClick={async () => {
+                                            popupRef.current?.close()
+                                            if (commentThreadRef.current?.getCommentText()) {
+                                                await commentThreadRef.current.submitComment()
+                                            }
+                                            await handleSaveComment()
+                                            setNavigateOnClose(true)
+                                        }}
+                                        disabled={isSavingComment}
+                                    >
+                                        {isSavingComment ? 'Saving...' : 'Return to Student for Revision'}
+                                    </Button>
+                                    <Button
+                                        variant="contained"
+                                        onClick={() => {
+                                            popupRef.current?.close()
+                                            handleApprove()
+                                        }}
+                                        disabled={isApproving}
+                                        color="success"
+                                    >
+                                        {isApproving ? 'Approving...' : 'Approve Step'}
+                                    </Button>
+                                </Stack>
+                            </Stack>
+                        </Paper>
+                    </Stack>
+                </Stack>
+            </Container>
+
+            {/* YouTube Video Modal */}
+            <Dialog
+                open={showYouTubePlayer}
+                onClose={() => setShowYouTubePlayer(false)}
+                maxWidth="lg"
+                fullWidth
+                PaperProps={{ sx: { height: '80vh', maxHeight: '80vh' } }}
+            >
+                <DialogTitle sx={{ pb: 1 }}>
+                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                        <Typography variant="h6">YouTube Video Submission</Typography>
+                        <IconButton onClick={() => setShowYouTubePlayer(false)}>
+                            <CloseIcon />
+                        </IconButton>
+                    </Box>
+                </DialogTitle>
+                <DialogContent>
+                    <Box
+                        sx={{
+                            position: 'relative',
+                            paddingBottom: '56.25%',
+                            height: 0,
+                            overflow: 'hidden',
+                            width: '100%',
+                            borderRadius: 1,
+                            bgcolor: '#000',
+                        }}
+                    >
+                        {youtubeLink && extractYouTubeVideoId(youtubeLink) ? (
+                            <iframe
+                                style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
+                                src={`https://www.youtube.com/embed/${extractYouTubeVideoId(youtubeLink)}`}
+                                title="YouTube video player"
+                                frameBorder="0"
+                                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                                allowFullScreen
+                            />
+                        ) : (
+                            <Box sx={{ p: 2 }}>
+                                <Typography color="error">Invalid YouTube URL</Typography>
+                            </Box>
+                        )}
+                    </Box>
+                </DialogContent>
+                <DialogActions sx={{ p: 2 }}>
+                    <Button onClick={() => setShowYouTubePlayer(false)} variant="contained">
+                        Close
+                    </Button>
+                </DialogActions>
+            </Dialog>
+
+            <AlertDialog
+                open={alertState.open}
+                title={alertState.title}
+                message={alertState.message}
+                onClose={() => {
+                    closeAlert()
+                    if (navigateOnClose) {
+                        setNavigateOnClose(false)
+                        navigate('/teacher/dashboard')
+                    }
+                }}
+            />
+        </Box>
+    )
 }

--- a/src/teacher/components/StepApproval/hooks/useData.ts
+++ b/src/teacher/components/StepApproval/hooks/useData.ts
@@ -1,120 +1,147 @@
-import { useEffect, useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
-import { auth } from '../../../../firebaseConfig';
-import { getDocument, getDocuments, buildConstraints } from '../../../../utils/firebaseHelpers';
-import { useAlert } from '../../../../hooks/useAlert';
+import { useEffect, useRef, useState } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { auth } from '../../../../firebaseConfig'
+import { getDocument, getDocuments, buildConstraints } from '../../../../utils/firebaseHelpers'
+import { useAlert } from '../../../../hooks/useAlert'
+import type { CommentThreadHandle } from '../../../../components/CommentThread/CommentThread'
 
 export function useStepApprovalData() {
-  const { projectId, stepNumber } = useParams();
-  const navigate = useNavigate();
-  const [project, setProject] = useState(null);
-  const [, setUser] = useState(null);
-  const [comment, setComment] = useState('');
-  const [submissionFile, setSubmissionFile] = useState(null);
-  const [youtubeLink, setYoutubeLink] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [submissionDownloadUrl, setSubmissionDownloadUrl] = useState<string | null>(null);
-  const [numPages, setNumPages] = useState(null);
-  const [pageNumber, setPageNumber] = useState(1);
-  const [scale, setScale] = useState(1.0);
-  const [isApproving, setIsApproving] = useState(false);
-  const [isSavingComment, setIsSavingComment] = useState(false);
-  const { alertState, showAlert, closeAlert } = useAlert();
+    const { projectId, stepNumber } = useParams()
+    const navigate = useNavigate()
+    const [project, setProject] = useState<any>(null)
+    const [comment, setComment] = useState('')
+    const [submissionFile, setSubmissionFile] = useState<string | null>(null)
+    const [youtubeLink, setYoutubeLink] = useState<string | null>(null)
+    const [loading, setLoading] = useState(true)
+    const [submissionDownloadUrl, setSubmissionDownloadUrl] = useState<string | null>(null)
+    const [numPages, setNumPages] = useState<number | null>(null)
+    const [pageNumber, setPageNumber] = useState(1)
+    const [scale, setScale] = useState(1.0)
+    const [isApproving, setIsApproving] = useState(false)
+    const [isSavingComment, setIsSavingComment] = useState(false)
+    const { alertState, showAlert, closeAlert } = useAlert()
 
-  useEffect(() => {
-    const fetchData = async () => {
-      // Reset state at start
-      setYoutubeLink(null);
-      setSubmissionFile(null);
+    // UI state for YouTube player and pop-out window
+    const [showYouTubePlayer, setShowYouTubePlayer] = useState(false)
+    const [isPoppedOut, setIsPoppedOut] = useState(false)
+    const [navigateOnClose, setNavigateOnClose] = useState(false)
 
-      const currentUser = auth.currentUser;
+    // Refs
+    const popupRef = useRef<Window | null>(null)
+    const containerRef = useRef<HTMLDivElement>(null)
+    const commentThreadRef = useRef<CommentThreadHandle>(null)
+    const pdfPageWidthRef = useRef<number>(612)
+    const pdfPageHeightRef = useRef<number>(792)
 
-      if (!currentUser) {
-        navigate('/login');
-        return;
-      }
+    // Poll the popup window to detect when it closes
+    useEffect(() => {
+        if (!isPoppedOut) return
+        const interval = setInterval(() => {
+            if (popupRef.current?.closed) {
+                setIsPoppedOut(false)
+                popupRef.current = null
+            }
+        }, 500)
+        return () => clearInterval(interval)
+    }, [isPoppedOut])
 
-      setUser(currentUser as any);
+    useEffect(() => {
+        const fetchData = async () => {
+            setYoutubeLink(null)
+            setSubmissionFile(null)
 
-      const { data: projectData, error: projectError } = await getDocument('projects', projectId!);
+            const currentUser = auth.currentUser
 
-      if (projectError || !projectData) {
-        console.error('Error fetching project:', projectError?.message);
-        navigate('/teacher/dashboard');
-        return;
-      }
+            if (!currentUser) {
+                navigate('/login')
+                return
+            }
 
-      // Get student data
-      const { data: studentData } = await getDocument('users', (projectData as any).student_id);
+            const { data: projectData, error: projectError } = await getDocument('projects', projectId!)
 
-      setProject({
-        ...projectData,
-        project_id: (projectData as any).id, // Map Firestore document ID to project_id
-        student: studentData,
-      } as any);
+            if (projectError || !projectData) {
+                console.error('Error fetching project:', projectError?.message)
+                navigate('/teacher/dashboard')
+                return
+            }
 
-      const { data: fileDataArray, error: fileError } = await getDocuments(
-        'submissions',
-        buildConstraints({
-          eq: { project_id: projectId, step_number: Number(stepNumber) },
-          orderBy: { field: 'submitted_at', direction: 'desc' },
-          limit: 1,
-        })
-      );
+            const { data: studentData } = await getDocument('users', (projectData as any).student_id)
 
-      if (fileError) {
-        console.error('Error fetching submission file:', fileError.message);
-      } else if (fileDataArray && (fileDataArray as any[]).length > 0) {
-        const latestSubmission = (fileDataArray as any[])[0];
+            setProject({
+                ...projectData,
+                project_id: (projectData as any).id,
+                student: studentData,
+            })
 
-        if (latestSubmission.youtube_link) {
-          console.log('Setting YouTube link:', latestSubmission.youtube_link);
-          setYoutubeLink(latestSubmission.youtube_link);
-        } else {
-          console.log('No YouTube link found in submission');
+            const { data: fileDataArray, error: fileError } = await getDocuments(
+                'submissions',
+                buildConstraints({
+                    eq: { project_id: projectId, step_number: Number(stepNumber) },
+                    orderBy: { field: 'submitted_at', direction: 'desc' },
+                    limit: 1,
+                })
+            )
+
+            if (fileError) {
+                console.error('Error fetching submission file:', fileError.message)
+            } else if (fileDataArray && (fileDataArray as any[]).length > 0) {
+                const latestSubmission = (fileDataArray as any[])[0]
+
+                if (latestSubmission.youtube_link) {
+                    setYoutubeLink(latestSubmission.youtube_link)
+                }
+
+                if (latestSubmission.file_url) {
+                    setSubmissionDownloadUrl(latestSubmission.file_url)
+                    setSubmissionFile(latestSubmission.file_url)
+                }
+
+                if (latestSubmission.teacher_comments) {
+                    setComment(latestSubmission.teacher_comments)
+                }
+            }
+
+            setLoading(false)
         }
 
-        if (latestSubmission.file_url) {
-          console.log('PDF file URL:', latestSubmission.file_url);
-          setSubmissionDownloadUrl(latestSubmission.file_url);
-          setSubmissionFile(latestSubmission.file_url);
-        }
+        fetchData()
+    }, [projectId, stepNumber, navigate])
 
-        if (latestSubmission.teacher_comments) {
-          setComment(latestSubmission.teacher_comments);
-        }
-      }
-
-      setLoading(false);
-    };
-
-    fetchData();
-  }, [projectId, stepNumber, navigate]);
-
-  return {
-    projectId,
-    stepNumber,
-    project,
-    comment,
-    setComment,
-    submissionFile,
-    setSubmissionFile,
-    submissionDownloadUrl,
-    youtubeLink,
-    loading,
-    numPages,
-    setNumPages,
-    pageNumber,
-    setPageNumber,
-    scale,
-    setScale,
-    isApproving,
-    setIsApproving,
-    isSavingComment,
-    setIsSavingComment,
-    navigate,
-    alertState,
-    showAlert,
-    closeAlert,
-  };
+    return {
+        projectId,
+        stepNumber,
+        project,
+        comment,
+        setComment,
+        submissionFile,
+        setSubmissionFile,
+        submissionDownloadUrl,
+        youtubeLink,
+        loading,
+        numPages,
+        setNumPages,
+        pageNumber,
+        setPageNumber,
+        scale,
+        setScale,
+        isApproving,
+        setIsApproving,
+        isSavingComment,
+        setIsSavingComment,
+        navigate,
+        alertState,
+        showAlert,
+        closeAlert,
+        showYouTubePlayer,
+        setShowYouTubePlayer,
+        isPoppedOut,
+        setIsPoppedOut,
+        navigateOnClose,
+        setNavigateOnClose,
+        popupRef,
+        containerRef,
+        commentThreadRef,
+        pdfPageWidthRef,
+        pdfPageHeightRef,
+    }
 }

--- a/src/teacher/components/StepApproval/hooks/useHandlers.ts
+++ b/src/teacher/components/StepApproval/hooks/useHandlers.ts
@@ -1,112 +1,162 @@
-import { updateDocument } from '../../../../utils/firebaseHelpers';
+import { useCallback } from 'react'
+import { updateDocument } from '../../../../utils/firebaseHelpers'
+import type { NavigateFunction } from 'react-router-dom'
 
-export function useStepApprovalHandlers(data: any) {
-  const {
-    projectId,
-    stepNumber,
-    setIsSavingComment,
-    setIsApproving,
-    navigate,
-    showAlert,
-  } = data;
+interface StepApprovalData {
+    projectId: string | undefined
+    stepNumber: string | undefined
+    setNumPages: (n: number) => void
+    setIsApproving: (v: boolean) => void
+    setIsSavingComment: (v: boolean) => void
+    setScale: (v: number | ((prev: number) => number)) => void
+    navigate: NavigateFunction
+    showAlert: (message: string, title: string) => void
+    containerRef: React.RefObject<HTMLDivElement>
+    pdfPageWidthRef: React.MutableRefObject<number>
+    pdfPageHeightRef: React.MutableRefObject<number>
+}
 
-  const onDocumentLoadSuccess = ({ numPages }) => {
-    data.setNumPages(numPages);
-    console.log('PDF loaded successfully, pages:', numPages);
-  };
+const STEP_NAMES: Record<number, string> = {
+    1: 'Initial Research',
+    2: 'Design Brief',
+    3: 'Planning',
+    4: 'Implementation',
+    5: 'Archival Records',
+}
 
-  const onDocumentLoadError = (error) => {
-    console.error('PDF load error:', error);
-    // Don't clear submissionFile here — pdfjs can fire worker errors during re-renders
-    // even after a successful load. Only log/alert; keep the viewer visible.
-    showAlert(
-      'Could not preview the submitted file. Use the download link to view it.',
-      'Preview Unavailable'
-    );
-  };
+export function useStepApprovalHandlers(data: StepApprovalData) {
+    const {
+        projectId,
+        stepNumber,
+        setNumPages,
+        setIsApproving,
+        setIsSavingComment,
+        setScale,
+        navigate,
+        showAlert,
+        containerRef,
+        pdfPageWidthRef,
+        pdfPageHeightRef,
+    } = data
 
-  const handleSaveComment = async () => {
-    setIsSavingComment(true);
+    const getStepName = useCallback((stepNum: number | string): string => {
+        return STEP_NAMES[Number(stepNum)] || 'Unknown'
+    }, [])
 
-    try {
-      const currentStepStatusField = `step${stepNumber}_status`;
-      const updateData = {
-        [currentStepStatusField]: 'Revision Requested',
-        current_step: parseInt(stepNumber),
-      };
+    const extractYouTubeVideoId = useCallback((url: string): string | null => {
+        if (!url) return null
+        const patterns = [
+            /(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&\n?#]+)/,
+            /youtube\.com\/embed\/([^&\n?#]+)/,
+            /youtube\.com\/v\/([^&\n?#]+)/,
+        ]
+        for (const pattern of patterns) {
+            const match = url.match(pattern)
+            if (match?.[1]) return match[1]
+        }
+        return null
+    }, [])
 
-      const { error: statusError } = await updateDocument('projects', projectId, updateData);
+    const onDocumentLoadSuccess = useCallback(({ numPages: n }: { numPages: number }) => {
+        setNumPages(n)
+    }, [setNumPages])
 
-      if (statusError) {
-        console.error('Error updating project status:', statusError.message);
-        showAlert('Error updating status. Please try again.', 'Error');
-      } else {
+    const onDocumentLoadError = useCallback((error: Error) => {
+        console.error('PDF load error:', error)
         showAlert(
-          'Revision requested. Student will see your feedback and can resubmit.',
-          'Success'
-        );
-      }
-    } catch (error) {
-      console.error('Error saving comment:', error);
-      showAlert('Error updating status. Please try again.', 'Error');
+            'Could not preview the submitted file. Use the download link to view it.',
+            'Preview Unavailable'
+        )
+    }, [showAlert])
+
+    const handleFitPage = useCallback(() => {
+        if (!containerRef.current) {
+            setScale(1)
+            return
+        }
+        const containerWidth = containerRef.current.clientWidth - 32
+        const containerHeight = containerRef.current.clientHeight - 32
+        const widthScale = containerWidth / pdfPageWidthRef.current
+        const heightScale = containerHeight / pdfPageHeightRef.current
+        setScale(Math.round(Math.min(widthScale, heightScale) * 100) / 100)
+    }, [setScale, containerRef, pdfPageWidthRef, pdfPageHeightRef])
+
+    const handlePageRenderSuccess = useCallback((page: any) => {
+        if (page?.originalWidth) pdfPageWidthRef.current = page.originalWidth
+        if (page?.originalHeight) pdfPageHeightRef.current = page.originalHeight
+    }, [pdfPageWidthRef, pdfPageHeightRef])
+
+    const handleSaveComment = useCallback(async () => {
+        setIsSavingComment(true)
+
+        try {
+            const currentStepStatusField = `step${stepNumber}_status`
+            const { error: statusError } = await updateDocument('projects', projectId!, {
+                [currentStepStatusField]: 'Revision Requested',
+                current_step: parseInt(stepNumber!),
+            })
+
+            if (statusError) {
+                console.error('Error updating project status:', statusError.message)
+                showAlert('Error updating status. Please try again.', 'Error')
+            } else {
+                showAlert(
+                    'Revision requested. Student will see your feedback and can resubmit.',
+                    'Success'
+                )
+            }
+        } catch (error) {
+            console.error('Error saving comment:', error)
+            showAlert('Error updating status. Please try again.', 'Error')
+        }
+
+        setIsSavingComment(false)
+    }, [projectId, stepNumber, setIsSavingComment, showAlert])
+
+    const handleApprove = useCallback(async () => {
+        setIsApproving(true)
+
+        try {
+            const currentStepStatusField = `step${stepNumber}_status`
+            const updateData: Record<string, string | number | boolean> = {
+                [currentStepStatusField]: 'Approved',
+            }
+
+            if (parseInt(stepNumber!) === 5) {
+                updateData.submitted_to_orbilius = true
+            }
+
+            if (parseInt(stepNumber!) < 5) {
+                const nextStep = parseInt(stepNumber!) + 1
+                updateData.current_step = nextStep
+                updateData[`step${nextStep}_status`] = 'In Progress'
+            }
+
+            const { error: updateError } = await updateDocument('projects', projectId!, updateData)
+
+            if (updateError) {
+                console.error('Error updating project:', updateError.message)
+                showAlert('Error approving step. Please try again.', 'Error')
+            } else {
+                showAlert('Step approved successfully!', 'Success')
+                navigate('/teacher/dashboard')
+            }
+        } catch (error) {
+            console.error('Error approving step:', error)
+            showAlert('Error approving step. Please try again.', 'Error')
+        }
+
+        setIsApproving(false)
+    }, [projectId, stepNumber, setIsApproving, showAlert, navigate])
+
+    return {
+        getStepName,
+        extractYouTubeVideoId,
+        onDocumentLoadSuccess,
+        onDocumentLoadError,
+        handleFitPage,
+        handlePageRenderSuccess,
+        handleSaveComment,
+        handleApprove,
     }
-
-    setIsSavingComment(false);
-  };
-
-  const handleApprove = async () => {
-    setIsApproving(true);
-
-    try {
-      const currentStepStatusField = `step${stepNumber}_status`;
-      const updateData: any = {
-        [currentStepStatusField]: 'Approved',
-      };
-
-      if (parseInt(stepNumber) === 5) {
-        updateData.submitted_to_orbilius = true;
-      }
-
-      if (parseInt(stepNumber) < 5) {
-        const nextStep = parseInt(stepNumber) + 1;
-        const nextStepStatusField = `step${nextStep}_status`;
-        updateData.current_step = nextStep;
-        updateData[nextStepStatusField] = 'In Progress';
-      }
-
-      const { error: updateError } = await updateDocument('projects', projectId, updateData);
-
-      if (updateError) {
-        console.error('Error updating project:', updateError.message);
-        showAlert('Error approving step. Please try again.', 'Error');
-      } else {
-        showAlert('Step approved successfully!', 'Success');
-        navigate('/teacher/dashboard');
-      }
-    } catch (error) {
-      console.error('Error approving step:', error);
-      showAlert('Error approving step. Please try again.', 'Error');
-    }
-
-    setIsApproving(false);
-  };
-
-  const getStepName = (stepNum) => {
-    const stepNames = {
-      1: 'Initial Research',
-      2: 'Design Brief',
-      3: 'Planning',
-      4: 'Implementation',
-      5: 'Archival Records',
-    };
-    return stepNames[stepNum] || 'Unknown';
-  };
-
-  return {
-    onDocumentLoadSuccess,
-    onDocumentLoadError,
-    handleSaveComment,
-    handleApprove,
-    getStepName,
-  };
 }

--- a/src/teacher/components/StepSubmissionModal/StepSubmissionModal.tsx
+++ b/src/teacher/components/StepSubmissionModal/StepSubmissionModal.tsx
@@ -114,15 +114,11 @@ export default function StepSubmissionModal({
 
           // Set YouTube link
           if (latestSubmission.youtube_link) {
-            console.log('Setting YouTube link:', latestSubmission.youtube_link);
             setYoutubeLink(latestSubmission.youtube_link);
-          } else {
-            console.log('No YouTube link found');
           }
 
           // Handle file URL
           if (latestSubmission.file_url) {
-            console.log('Fetching PDF from:', latestSubmission.file_url);
             setSubmissionFile(latestSubmission.file_url);
           }
 


### PR DESCRIPTION
## Summary

Code cleanup pass across the codebase.

### Console.log removal
- Removed all debug `console.log` statements throughout the codebase
- Security fix: `firebaseConfig.ts` was logging API keys to the console

### Hook architecture refactor (Steps 1–5 Upload components)
Each Step*Upload component now fully follows the 3-file hook pattern:

**`useData.ts`**
- Moved `useNavigate` / `navigate` creation inside the hook (removed `navigate` param from callers)
- Added `isDragging` state, `dragCounterRef`, and `justDroppedRef` refs

**`useHandlers.ts`**
- Added typed params: `setIsDragging`, `dragCounterRef`, `justDroppedRef`
- Added 6 new handlers moved out of TSX: `handleDragEnter`, `handleDragLeave`, `handleDragOver`, `handleDragEnd`, `handleDrop`, `handleDropZoneClick`
- Fixed `React.DragEvent<HTMLElement>` types (previously used DOM `DragEvent`, incompatible with MUI Paper event props)

**TSX files**
- Removed all inline `useState`, `useRef`, `useNavigate`, drag handler functions, and inline JSX lambdas
- Components are now pure render files

### Other fixes
- `StepApproval.tsx`: Fixed truncation (leftover old JSX appended after new content)
- `Dashboard.tsx`: Removed duplicate `<Button>` JSX artifact
- Refactored `Dashboard` and `StepApproval` to use `useData`/`useHandlers` hook pattern