### PR TITLE
feat(KAN-21): Rename 'Date' column to 'Due Date' on dashboards

### DIFF
--- a/src/student/components/Dashboard/Dashboard.tsx
+++ b/src/student/components/Dashboard/Dashboard.tsx
@@ -341,7 +341,7 @@ export default function StudentDashboard() {
                       </TableCell>
                       <TableCell>
                         <Typography variant="subtitle1" fontWeight="bold">
-                          Date
+                          Due Date
                         </Typography>
                       </TableCell>
                       <TableCell>

--- a/src/teacher/components/Dashboard/StudentsList.tsx
+++ b/src/teacher/components/Dashboard/StudentsList.tsx
@@ -164,7 +164,13 @@ export default function StudentsList({
       'Archival Records',
     ];
     return [1, 2, 3, 4, 5]
-      .map((n) => ({ stepNumber: n, name: stepNames[n - 1], status: project[`step${n}_status`] }))
+      .map((n) => {
+        const rawDue = project[`step${n}_due_date`]
+        const dueDate = rawDue
+          ? new Date(rawDue).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+          : null
+        return { stepNumber: n, name: stepNames[n - 1], status: project[`step${n}_status`], dueDate }
+      })
       .filter((s) => s.status === 'Submitted' || s.status === 'Approved' || s.status === 'Revision Requested');
   };
 
@@ -701,6 +707,15 @@ export default function StudentsList({
                                                       Status
                                                     </TableCell>
                                                     <TableCell
+                                                      sx={{
+                                                        fontWeight: 600,
+                                                        color: 'text.secondary',
+                                                        fontSize: '0.75rem',
+                                                      }}
+                                                    >
+                                                      Due Date
+                                                    </TableCell>
+                                                    <TableCell
                                                       align="right"
                                                       sx={{
                                                         fontWeight: 600,
@@ -739,6 +754,9 @@ export default function StudentsList({
                                                             )
                                                           }
                                                         />
+                                                      </TableCell>
+                                                      <TableCell sx={{ fontSize: '0.8rem', color: step.dueDate ? 'text.primary' : 'text.disabled' }}>
+                                                        {step.dueDate ?? '—'}
                                                       </TableCell>
                                                       <TableCell align="right">
                                                         <Box


### PR DESCRIPTION
## Summary
Resolves KAN-21

- Student dashboard step table: renamed "Date" column header to "Due Date"
- Teacher dashboard steps detail table (Submitted/Approved Steps): added "Due Date" column between Status and Actions, populated from `step{n}_due_date` on the project