### PR TITLE
feat(KAN-22): Warn teacher about unsaved comment before Approve or Revision Request

### DIFF
--- a/src/teacher/components/StepApproval/StepApproval.tsx
+++ b/src/teacher/components/StepApproval/StepApproval.tsx
@@ -104,6 +104,8 @@ export default function StepApproval() {
         popupRef,
         containerRef,
         commentThreadRef,
+        draftCommentDialog,
+        setDraftCommentDialog,
     } = data
 
     const {
@@ -115,6 +117,10 @@ export default function StepApproval() {
         handlePageRenderSuccess,
         handleSaveComment,
         handleApprove,
+        handleApproveGuarded,
+        handleRevisionGuarded,
+        handleConfirmWithComment,
+        handleConfirmWithoutComment,
     } = handlers
 
     if (loading) {
@@ -364,14 +370,7 @@ export default function StepApproval() {
                                         variant="contained"
                                         color="warning"
                                         size="large"
-                                        onClick={async () => {
-                                            popupRef.current?.close()
-                                            if (commentThreadRef.current?.getCommentText()) {
-                                                await commentThreadRef.current.submitComment()
-                                            }
-                                            await handleSaveComment()
-                                            setNavigateOnClose(true)
-                                        }}
+                                        onClick={handleRevisionGuarded}
                                         disabled={isSavingComment}
                                         sx={{ fontWeight: 700 }}
                                     >
@@ -380,10 +379,7 @@ export default function StepApproval() {
                                     <Button
                                         variant="contained"
                                         size="large"
-                                        onClick={() => {
-                                            popupRef.current?.close()
-                                            handleApprove()
-                                        }}
+                                        onClick={handleApproveGuarded}
                                         disabled={isApproving}
                                         color="success"
                                         sx={{ fontWeight: 700 }}
@@ -396,6 +392,36 @@ export default function StepApproval() {
                     </Stack>
                 </Stack>
             </Container>
+
+            {/* Draft comment warning dialog */}
+            <Dialog open={draftCommentDialog !== null} onClose={() => setDraftCommentDialog(null)} maxWidth="sm" fullWidth>
+                <DialogTitle>
+                    You have an unsaved comment
+                </DialogTitle>
+                <DialogContent>
+                    <Typography>
+                        You typed a comment but haven't submitted it yet. Would you like to include it with your{' '}
+                        <strong>{draftCommentDialog === 'approve' ? 'Approval' : 'Revision Request'}</strong>?
+                    </Typography>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => setDraftCommentDialog(null)}>
+                        Cancel
+                    </Button>
+                    <Button
+                        onClick={() => { setDraftCommentDialog(null); handleConfirmWithoutComment(draftCommentDialog!) }}
+                    >
+                        {draftCommentDialog === 'approve' ? 'Approve Without Comment' : 'Request Revision Without Comment'}
+                    </Button>
+                    <Button
+                        variant="contained"
+                        color={draftCommentDialog === 'approve' ? 'success' : 'warning'}
+                        onClick={() => { setDraftCommentDialog(null); handleConfirmWithComment(draftCommentDialog!) }}
+                    >
+                        Submit Comment + {draftCommentDialog === 'approve' ? 'Approve' : 'Request Revision'}
+                    </Button>
+                </DialogActions>
+            </Dialog>
 
             {/* YouTube Video Modal */}
             <Dialog

--- a/src/teacher/components/StepApproval/hooks/useData.ts
+++ b/src/teacher/components/StepApproval/hooks/useData.ts
@@ -19,6 +19,7 @@ export function useStepApprovalData() {
     const [scale, setScale] = useState(1.0)
     const [isApproving, setIsApproving] = useState(false)
     const [isSavingComment, setIsSavingComment] = useState(false)
+    const [draftCommentDialog, setDraftCommentDialog] = useState<'approve' | 'revision' | null>(null)
     const { alertState, showAlert, closeAlert } = useAlert()
 
     // UI state for YouTube player and pop-out window
@@ -143,5 +144,7 @@ export function useStepApprovalData() {
         commentThreadRef,
         pdfPageWidthRef,
         pdfPageHeightRef,
+        draftCommentDialog,
+        setDraftCommentDialog,
     }
 }

--- a/src/teacher/components/StepApproval/hooks/useHandlers.ts
+++ b/src/teacher/components/StepApproval/hooks/useHandlers.ts
@@ -14,6 +14,10 @@ interface StepApprovalData {
     containerRef: React.RefObject<HTMLDivElement>
     pdfPageWidthRef: React.MutableRefObject<number>
     pdfPageHeightRef: React.MutableRefObject<number>
+    commentThreadRef: React.RefObject<{ getCommentText: () => string; submitComment: () => Promise<void> }>
+    setDraftCommentDialog: (v: 'approve' | 'revision' | null) => void
+    popupRef: React.MutableRefObject<Window | null>
+    setNavigateOnClose: (v: boolean) => void
 }
 
 const STEP_NAMES: Record<number, string> = {
@@ -37,6 +41,10 @@ export function useStepApprovalHandlers(data: StepApprovalData) {
         containerRef,
         pdfPageWidthRef,
         pdfPageHeightRef,
+        commentThreadRef,
+        setDraftCommentDialog,
+        popupRef,
+        setNavigateOnClose,
     } = data
 
     const getStepName = useCallback((stepNum: number | string): string => {
@@ -149,6 +157,52 @@ export function useStepApprovalHandlers(data: StepApprovalData) {
         setIsApproving(false)
     }, [projectId, stepNumber, setIsApproving, showAlert, navigate])
 
+    // Check for unsaved draft comment before executing approve or revision request.
+    // If draft exists, open the confirmation dialog instead.
+    const handleApproveGuarded = useCallback(() => {
+        if (commentThreadRef.current?.getCommentText()?.trim()) {
+            setDraftCommentDialog('approve')
+        } else {
+            popupRef.current?.close()
+            handleApprove()
+        }
+    }, [commentThreadRef, setDraftCommentDialog, popupRef, handleApprove])
+
+    const handleRevisionGuarded = useCallback(() => {
+        if (commentThreadRef.current?.getCommentText()?.trim()) {
+            setDraftCommentDialog('revision')
+        } else {
+            popupRef.current?.close()
+            handleSaveComment()
+            setNavigateOnClose(true)
+        }
+    }, [commentThreadRef, setDraftCommentDialog, popupRef, handleSaveComment, setNavigateOnClose])
+
+    // Called from dialog: submit the draft comment first, then run the action
+    const handleConfirmWithComment = useCallback(async (action: 'approve' | 'revision') => {
+        if (commentThreadRef.current?.getCommentText()?.trim()) {
+            await commentThreadRef.current.submitComment()
+        }
+        popupRef.current?.close()
+        if (action === 'approve') {
+            handleApprove()
+        } else {
+            handleSaveComment()
+            setNavigateOnClose(true)
+        }
+    }, [commentThreadRef, popupRef, handleApprove, handleSaveComment, setNavigateOnClose])
+
+    // Called from dialog: skip the comment and run the action
+    const handleConfirmWithoutComment = useCallback((action: 'approve' | 'revision') => {
+        popupRef.current?.close()
+        if (action === 'approve') {
+            handleApprove()
+        } else {
+            handleSaveComment()
+            setNavigateOnClose(true)
+        }
+    }, [popupRef, handleApprove, handleSaveComment, setNavigateOnClose])
+
     return {
         getStepName,
         extractYouTubeVideoId,
@@ -158,5 +212,9 @@ export function useStepApprovalHandlers(data: StepApprovalData) {
         handlePageRenderSuccess,
         handleSaveComment,
         handleApprove,
+        handleApproveGuarded,
+        handleRevisionGuarded,
+        handleConfirmWithComment,
+        handleConfirmWithoutComment,
     }
 }


### PR DESCRIPTION
## Summary
Resolves KAN-22

If a teacher types a comment in the compose box but hasn't formally submitted it before clicking Approve or Revision Request, the comment was silently lost. This PR adds a confirmation dialog to prevent that.

### Behavior
- Clicking **Approve Step** or **Return to Student for Revision** now checks for unsaved draft text in the comment box
- If draft text exists, a dialog appears with three options:
  - **Cancel** — go back and review
  - **Approve/Request Revision Without Comment** — discard the draft and proceed
  - **Submit Comment + Approve/Request Revision** — submits the draft comment first, then executes the action