### PR TITLE
feat(KAN-24): Add show/hide password toggle to Login and Signup

### DIFF
--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -1,5 +1,8 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Box, Card, CardContent, TextField, Button, Typography, Stack } from '@mui/material';
+import { Box, Card, CardContent, TextField, Button, Typography, Stack, InputAdornment, IconButton } from '@mui/material';
+import Visibility from '@mui/icons-material/Visibility';
+import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import { useLoginData } from './hooks/useData';
 import { useLoginHandlers } from './hooks/useHandlers';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -8,6 +11,7 @@ import regularLogo from '../../assets/merle-386x386.svg';
 import AlertDialog from '../AlertDialog/AlertDialog';
 
 export default function Login() {
+  const [showPassword, setShowPassword] = useState(false);
   const { currentTheme } = useTheme();
   const merleLogo = currentTheme === 'light' ? regularLogo : yellowLogo;
   const data = useLoginData();
@@ -58,12 +62,21 @@ export default function Login() {
             />
 
             <TextField
-              type="password"
+              type={showPassword ? 'text' : 'password'}
               label="Password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               fullWidth
               variant="outlined"
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton onClick={() => setShowPassword(p => !p)} edge="end" tabIndex={-1}>
+                      {showPassword ? <VisibilityOff /> : <Visibility />}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              }}
             />
 
             <Button

--- a/src/components/Signup/Signup.tsx
+++ b/src/components/Signup/Signup.tsx
@@ -11,7 +11,11 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
+  InputAdornment,
+  IconButton,
 } from '@mui/material';
+import Visibility from '@mui/icons-material/Visibility';
+import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import { useState } from 'react';
 import { useSignupData } from './hooks/useData';
 import { useSignupHandlers } from './hooks/useHandlers';
@@ -24,6 +28,7 @@ export default function Signup() {
   const { currentTheme } = useTheme();
   const merleLogo = currentTheme === 'light' ? regularLogo : yellowLogo;
   const [showEmailModal, setShowEmailModal] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
   const [touchedFields, setTouchedFields] = useState({
     firstName: false,
     lastName: false,
@@ -190,7 +195,7 @@ export default function Signup() {
             />
 
             <TextField
-              type="password"
+              type={showPassword ? 'text' : 'password'}
               label="Password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
@@ -205,10 +210,19 @@ export default function Signup() {
                   ? 'Password must be at least 6 characters'
                   : ''
               }
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton onClick={() => setShowPassword(p => !p)} edge="end" tabIndex={-1}>
+                      {showPassword ? <VisibilityOff /> : <Visibility />}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              }}
             />
 
             <TextField
-              type="password"
+              type={showPassword ? 'text' : 'password'}
               label="Confirm Password"
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}


### PR DESCRIPTION
## KAN-24: View password

### Changes
- Eye icon button added to the Password field on both Login and Signup screens
- Clicking the eye toggles password visibility
- On Signup, one toggle controls both Password and Confirm Password fields simultaneously
- Eye button excluded from tab order (`tabIndex={-1}`)