### PR TITLE
feat(KAN-25): Limit first and last name to 20 characters on Signup

### DIFF
--- a/src/components/Signup/Signup.tsx
+++ b/src/components/Signup/Signup.tsx
@@ -157,6 +157,7 @@ export default function Signup() {
               variant="outlined"
               required
               autoComplete="off"
+              inputProps={{ maxLength: 20 }}
               error={touchedFields.firstName && !isFirstNameValid}
               helperText={
                 touchedFields.firstName && !isFirstNameValid ? 'First name is required' : ''
@@ -173,6 +174,7 @@ export default function Signup() {
               variant="outlined"
               required
               autoComplete="off"
+              inputProps={{ maxLength: 20 }}
               error={touchedFields.lastName && !isLastNameValid}
               helperText={touchedFields.lastName && !isLastNameValid ? 'Last name is required' : ''}
             />


### PR DESCRIPTION
## KAN-25: Character limit on name fields

### Changes
- First Name and Last Name fields on Signup now enforce a 20-character maximum via `inputProps={{ maxLength: 20 }}`
- Enforced at the HTML input level — no additional validation logic required